### PR TITLE
Refactor pointers

### DIFF
--- a/.github/workflows/cmake_test.yml
+++ b/.github/workflows/cmake_test.yml
@@ -1,4 +1,4 @@
-name: CMake
+name: "CMake - Run Tests"
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   Testing:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   analyze:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vscode/*
 !.vscode/c_cpp_properties.json
 build/
+debug/
 # users can put their content within the content directory without causing git problems
 content/*
 !content/README.md

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,3 +13,7 @@ configure_file(dnd_config.hpp.in dnd_config.hpp)
 add_subdirectory(controllers)
 add_subdirectory(models)
 add_subdirectory(parsing)
+
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_subdirectory(runtime_measurement)
+endif()

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -15,7 +15,7 @@ namespace dnd {
 class Content {
 public:
     std::unordered_map<std::string, std::shared_ptr<const Spell>> spells;
-    std::unordered_map<std::string, std::shared_ptr<Character>> characters;
+    std::unordered_map<std::string, std::unique_ptr<Character>> characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -19,7 +19,7 @@ public:
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> character_subraces;
+    std::unordered_map<std::string, const CharacterSubrace> character_subraces;
     void printStatus() const;
 };
 

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -14,12 +14,12 @@ namespace dnd {
 
 class Content {
 public:
-    std::unordered_map<std::string, const Spell> spells;
     std::unordered_map<std::string, Character> characters;
     std::unordered_map<std::string, const CharacterClass> character_classes;
     std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     std::unordered_map<std::string, const CharacterRace> character_races;
     std::unordered_map<std::string, const CharacterSubrace> character_subraces;
+    std::unordered_map<std::string, const Spell> spells;
     void printStatus() const;
 };
 

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -15,7 +15,7 @@ namespace dnd {
 class Content {
 public:
     std::unordered_map<std::string, const Spell> spells;
-    std::unordered_map<std::string, std::unique_ptr<Character>> characters;
+    std::unordered_map<std::string, Character> characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -16,7 +16,7 @@ class Content {
 public:
     std::unordered_map<std::string, const Spell> spells;
     std::unordered_map<std::string, Character> characters;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
+    std::unordered_map<std::string, const CharacterClass> character_classes;
     std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
     std::unordered_map<std::string, const CharacterSubrace> character_subraces;

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -14,7 +14,7 @@ namespace dnd {
 
 class Content {
 public:
-    std::unordered_map<std::string, std::shared_ptr<const Spell>> spells;
+    std::unordered_map<std::string, const Spell> spells;
     std::unordered_map<std::string, std::unique_ptr<Character>> characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -17,7 +17,7 @@ public:
     std::unordered_map<std::string, const Spell> spells;
     std::unordered_map<std::string, Character> characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
+    std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> character_subraces;
     void printStatus() const;

--- a/src/controllers/content.hpp
+++ b/src/controllers/content.hpp
@@ -18,7 +18,7 @@ public:
     std::unordered_map<std::string, Character> characters;
     std::unordered_map<std::string, const CharacterClass> character_classes;
     std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
+    std::unordered_map<std::string, const CharacterRace> character_races;
     std::unordered_map<std::string, const CharacterSubrace> character_subraces;
     void printStatus() const;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include "launcher.hpp"
 
 int main(int argc, char** argv) {
-    DND_START_MEASURING_SESSION("LAUNCH", "runtime_measurement_results.json");
+    DND_START_MEASURING_SESSION("LAUNCH", "debug/runtime_measurement_results.json");
     { DND_MEASURE_SCOPE("FIRST"); }
     auto rv = dnd::launch(argc, argv);
     DND_END_MEASURING_SESSION();

--- a/src/models/character.cpp
+++ b/src/models/character.cpp
@@ -50,6 +50,7 @@ const std::unordered_map<std::string, int> dnd::Character::getInitialAttributeVa
 void dnd::Character::determineState() {
     state.reset(getConstants(), getInitialAttributeValues());
 
+    state.addFeatureHolder(this);
     state.addFeatureHolder(class_ptr);
     state.addFeatureHolder(subclass_ptr);
     state.addFeatureHolder(race_ptr);

--- a/src/models/character.cpp
+++ b/src/models/character.cpp
@@ -62,23 +62,23 @@ void dnd::Character::determineState() {
 std::vector<const dnd::Feature*> dnd::Character::allFeatures() const {
     std::vector<const Feature*> all_features;
 
-    for (auto it = class_ptr->features.cbegin(); it != class_ptr->features.cend(); ++it) {
-        all_features.push_back(it->get());
+    for (const auto& feature : class_ptr->features) {
+        all_features.emplace_back(&feature);
     }
 
     if (subclass_ptr != nullptr) {
-        for (auto it = subclass_ptr->features.cbegin(); it != subclass_ptr->features.cend(); ++it) {
-            all_features.push_back(it->get());
+        for (const auto& feature : subclass_ptr->features) {
+            all_features.emplace_back(&feature);
         }
     }
 
-    for (auto it = race_ptr->features.cbegin(); it != race_ptr->features.cend(); ++it) {
-        all_features.push_back(it->get());
+    for (const auto& feature : race_ptr->features) {
+        all_features.emplace_back(&feature);
     }
 
     if (subrace_ptr != nullptr) {
-        for (auto it = subrace_ptr->features.cbegin(); it != subrace_ptr->features.cend(); ++it) {
-            all_features.push_back(it->get());
+        for (const auto& feature : subrace_ptr->features) {
+            all_features.emplace_back(&feature);
         }
     }
     return all_features;

--- a/src/models/character.cpp
+++ b/src/models/character.cpp
@@ -59,14 +59,27 @@ void dnd::Character::determineState() {
     state.calculate();
 }
 
-std::vector<std::shared_ptr<const dnd::Feature>> dnd::Character::allFeatures() const {
-    std::vector<std::shared_ptr<const dnd::Feature>> all_features = class_ptr->features;
-    if (subclass_ptr != nullptr) {
-        all_features.insert(all_features.end(), subclass_ptr->features.cbegin(), subclass_ptr->features.cend());
+std::vector<const dnd::Feature*> dnd::Character::allFeatures() const {
+    std::vector<const Feature*> all_features;
+
+    for (auto it = class_ptr->features.cbegin(); it != class_ptr->features.cend(); ++it) {
+        all_features.push_back(it->get());
     }
-    all_features.insert(all_features.end(), race_ptr->features.cbegin(), race_ptr->features.cend());
+
+    if (subclass_ptr != nullptr) {
+        for (auto it = subclass_ptr->features.cbegin(); it != subclass_ptr->features.cend(); ++it) {
+            all_features.push_back(it->get());
+        }
+    }
+
+    for (auto it = race_ptr->features.cbegin(); it != race_ptr->features.cend(); ++it) {
+        all_features.push_back(it->get());
+    }
+
     if (subrace_ptr != nullptr) {
-        all_features.insert(all_features.end(), subrace_ptr->features.cbegin(), subrace_ptr->features.cend());
+        for (auto it = subrace_ptr->features.cbegin(); it != subrace_ptr->features.cend(); ++it) {
+            all_features.push_back(it->get());
+        }
     }
     return all_features;
 }

--- a/src/models/character.hpp
+++ b/src/models/character.hpp
@@ -30,10 +30,10 @@ protected:
     virtual const std::unordered_map<std::string, int> getInitialAttributeValues() const;
 public:
     // TODO: should these pointers be non-const?
-    std::shared_ptr<const CharacterClass> class_ptr;
-    std::shared_ptr<const CharacterSubclass> subclass_ptr;
-    std::shared_ptr<const CharacterRace> race_ptr;
-    std::shared_ptr<const CharacterSubrace> subrace_ptr;
+    const CharacterClass* class_ptr;
+    const CharacterSubclass* subclass_ptr;
+    const CharacterRace* race_ptr;
+    const CharacterSubrace* subrace_ptr;
     Character(const std::string& name, const std::array<int, 6>& base_ability_scores);
     Character(
         const std::string& name, const std::array<int, 6>& base_ability_scores, int level, int xp,

--- a/src/models/character.hpp
+++ b/src/models/character.hpp
@@ -50,8 +50,8 @@ public:
     static int levelForXP(int xp);
     void addHitDiceRoll(int hit_dice_roll);
     virtual void determineState();
-    const std::vector<std::shared_ptr<const Feature>>& activeFeatures() const;
-    std::vector<std::shared_ptr<const Feature>> allFeatures() const;
+    const std::vector<const Feature*>& activeFeatures() const;
+    std::vector<const Feature*> allFeatures() const;
 };
 
 inline Character::Character(const std::string& name, const std::array<int, 6>& base_ability_scores)
@@ -117,9 +117,7 @@ inline void Character::addHitDiceRoll(int hit_dice_roll) {
     }
 }
 
-inline const std::vector<std::shared_ptr<const Feature>>& Character::activeFeatures() const {
-    return state.active_features;
-}
+inline const std::vector<const Feature*>& Character::activeFeatures() const { return state.active_features; }
 
 } // namespace dnd
 

--- a/src/models/creature_state.cpp
+++ b/src/models/creature_state.cpp
@@ -49,9 +49,9 @@ void dnd::CreatureState::addFeatureHolder(const FeatureHolder* const feature_hol
     if (feature_holder_ptr == nullptr) {
         return;
     }
-    for (const auto& feature_ptr : feature_holder_ptr->features) {
-        if (feature_ptr->isActive(attributes, constants)) {
-            active_features.push_back(feature_ptr.get());
+    for (const auto& feature : feature_holder_ptr->features) {
+        if (feature.isActive(attributes, constants)) {
+            active_features.emplace_back(&feature);
         }
     }
 }

--- a/src/models/creature_state.cpp
+++ b/src/models/creature_state.cpp
@@ -51,7 +51,7 @@ void dnd::CreatureState::addFeatureHolder(const FeatureHolder* const feature_hol
     }
     for (const auto& feature_ptr : feature_holder_ptr->features) {
         if (feature_ptr->isActive(attributes, constants)) {
-            active_features.push_back(feature_ptr);
+            active_features.push_back(feature_ptr.get());
         }
     }
 }

--- a/src/models/creature_state.cpp
+++ b/src/models/creature_state.cpp
@@ -45,7 +45,7 @@ void dnd::CreatureState::determineModifiers() {
     }
 }
 
-void dnd::CreatureState::addFeatureHolder(std::shared_ptr<const dnd::FeatureHolder> feature_holder_ptr) {
+void dnd::CreatureState::addFeatureHolder(const FeatureHolder* const feature_holder_ptr) {
     if (feature_holder_ptr == nullptr) {
         return;
     }

--- a/src/models/creature_state.hpp
+++ b/src/models/creature_state.hpp
@@ -32,7 +32,7 @@ class CreatureState {
 public:
     std::unordered_map<std::string, int> constants;
     std::unordered_map<std::string, int> attributes;
-    std::vector<std::shared_ptr<const Feature>> active_features;
+    std::vector<const Feature*> active_features;
     ActionHolder actions;
     ProficiencyHolder proficiencies;
     RIVHolder rivs;

--- a/src/models/creature_state.hpp
+++ b/src/models/creature_state.hpp
@@ -45,7 +45,7 @@ public:
         const std::unordered_map<std::string, int>& new_constants,
         const std::unordered_map<std::string, int>& new_initial_attributes
     );
-    void addFeatureHolder(std::shared_ptr<const FeatureHolder> feature_holder_ptr);
+    void addFeatureHolder(const FeatureHolder* const feature_holder_ptr);
     void calculate();
     static int modifier(int ability_score);
     static bool isAbility(const std::string& attribute_name);

--- a/src/models/feature_holder.hpp
+++ b/src/models/feature_holder.hpp
@@ -12,7 +12,7 @@ class FeatureHolder {
 public:
     const std::string name;
     // TODO: should this really be public AND non-const?
-    std::vector<std::shared_ptr<const Feature>> features;
+    std::vector<Feature> features;
     FeatureHolder(const std::string& name);
 };
 

--- a/src/models/features/feature.hpp
+++ b/src/models/features/feature.hpp
@@ -23,6 +23,7 @@ public:
     ProficiencyHolder proficiencies;
     RIVHolder rivs;
     std::unordered_map<EffectTime, std::vector<std::unique_ptr<const Effect>>> ability_score_effects, normal_effects;
+    Feature(Feature&& other) = default;
     Feature(const std::string& name, const std::string& description);
     bool isActive(
         std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants

--- a/src/models/spell.hpp
+++ b/src/models/spell.hpp
@@ -63,6 +63,7 @@ public:
     const std::string name, casting_time, range, duration, description;
     const SpellType type;
     const SpellComponents components;
+    Spell() = delete;
     Spell(
         const std::string& name, const SpellType& type, const std::string& casting_time, const std::string& range,
         const SpellComponents& components, const std::string& duration, const std::string& description

--- a/src/parsing/content_parser.cpp
+++ b/src/parsing/content_parser.cpp
@@ -25,13 +25,19 @@
 #include "parsing/parsing_exceptions.hpp"
 #include "parsing/parsing_types.hpp"
 
-void dnd::ContentParser::reset() {
-    parsed_spells = {};
-    parsed_characters = {};
-    parsed_character_classes = {};
-    parsed_character_subclasses = {};
-    parsed_character_races = {};
-    parsed_character_subraces = {};
+void dnd::ContentParser::resetParsed() {
+    std::unordered_map<std::string, std::shared_ptr<const Spell>> empty_spells_map;
+    std::unordered_map<std::string, std::unique_ptr<Character>> empty_characters_map;
+    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> empty_character_classes_map;
+    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> empty_character_subclasses_map;
+    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> empty_character_races_map;
+    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> empty_character_subraces_map;
+    parsed_spells.swap(empty_spells_map);
+    parsed_characters.swap(empty_characters_map);
+    parsed_character_classes.swap(empty_character_classes_map);
+    parsed_character_subclasses.swap(empty_character_subclasses_map);
+    parsed_character_races.swap(empty_character_races_map);
+    parsed_character_subraces.swap(empty_character_subraces_map);
 }
 
 dnd::Content dnd::ContentParser::parse(
@@ -76,12 +82,13 @@ dnd::Content dnd::ContentParser::parse(
 
     // TODO: change Content constructor
     Content content;
-    content.spells = parsed_spells;
-    content.characters = parsed_characters;
-    content.character_classes = parsed_character_classes;
-    content.character_subclasses = parsed_character_subclasses;
-    content.character_races = parsed_character_races;
-    content.character_subraces = parsed_character_subraces;
+    content.spells = std::move(parsed_spells);
+    content.characters = std::move(parsed_characters);
+    content.character_classes = std::move(parsed_character_classes);
+    content.character_subclasses = std::move(parsed_character_subclasses);
+    content.character_races = std::move(parsed_character_races);
+    content.character_subraces = std::move(parsed_character_subraces);
+    resetParsed();
     return content;
 }
 

--- a/src/parsing/content_parser.cpp
+++ b/src/parsing/content_parser.cpp
@@ -64,10 +64,10 @@ dnd::Content dnd::ContentParser::parse(
     dirs_to_parse.push_back(std::filesystem::directory_entry(content_path / campaign_dir_name));
     try {
         parseAllOfType(ParsingType::SPELL, dirs_to_parse);
-        parseAllOfType(ParsingType::RACE, dirs_to_parse);
         parseAllOfType(ParsingType::CLASS, dirs_to_parse);
-        parseAllOfType(ParsingType::SUBRACE, dirs_to_parse);
+        parseAllOfType(ParsingType::RACE, dirs_to_parse);
         parseAllOfType(ParsingType::SUBCLASS, dirs_to_parse);
+        parseAllOfType(ParsingType::SUBRACE, dirs_to_parse);
         parseAllOfType(ParsingType::CHARACTER, dirs_to_parse);
     } catch (parsing_error& e) {
         e.relativiseFileName(content_path);
@@ -76,12 +76,12 @@ dnd::Content dnd::ContentParser::parse(
 
     // TODO: change Content constructor
     Content content;
-    content.spells = std::move(parsed_spells);
     content.characters = std::move(parsed_characters);
     content.character_classes = std::move(parsed_character_classes);
     content.character_subclasses = std::move(parsed_character_subclasses);
     content.character_races = std::move(parsed_character_races);
     content.character_subraces = std::move(parsed_character_subraces);
+    content.spells = std::move(parsed_spells);
     resetParsed();
     return content;
 }

--- a/src/parsing/content_parser.cpp
+++ b/src/parsing/content_parser.cpp
@@ -26,18 +26,12 @@
 #include "parsing/parsing_types.hpp"
 
 void dnd::ContentParser::resetParsed() {
-    std::unordered_map<std::string, std::shared_ptr<const Spell>> empty_spells_map;
-    std::unordered_map<std::string, std::unique_ptr<Character>> empty_characters_map;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> empty_character_classes_map;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> empty_character_subclasses_map;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> empty_character_races_map;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> empty_character_subraces_map;
-    parsed_spells.swap(empty_spells_map);
-    parsed_characters.swap(empty_characters_map);
-    parsed_character_classes.swap(empty_character_classes_map);
-    parsed_character_subclasses.swap(empty_character_subclasses_map);
-    parsed_character_races.swap(empty_character_races_map);
-    parsed_character_subraces.swap(empty_character_subraces_map);
+    parsed_characters.clear();
+    parsed_character_classes.clear();
+    parsed_character_subclasses.clear();
+    parsed_character_races.clear();
+    parsed_character_subraces.clear();
+    parsed_spells.clear();
 }
 
 dnd::Content dnd::ContentParser::parse(

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -25,7 +25,7 @@ private:
     static const std::unordered_map<ParsingType, std::string> subdir_names;
     std::unordered_map<std::string, const Spell> parsed_spells;
     std::unordered_map<std::string, Character> parsed_characters;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
+    std::unordered_map<std::string, const CharacterClass> parsed_character_classes;
     std::unordered_map<std::string, const CharacterSubclass> parsed_character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;
     std::unordered_map<std::string, const CharacterSubrace> parsed_character_subraces;

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -23,7 +23,7 @@ namespace dnd {
 class ContentParser {
 private:
     static const std::unordered_map<ParsingType, std::string> subdir_names;
-    std::unordered_map<std::string, std::shared_ptr<const Spell>> parsed_spells;
+    std::unordered_map<std::string, const Spell> parsed_spells;
     std::unordered_map<std::string, std::unique_ptr<Character>> parsed_characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> parsed_character_subclasses;

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -28,7 +28,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
     std::unordered_map<std::string, const CharacterSubclass> parsed_character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> parsed_character_subraces;
+    std::unordered_map<std::string, const CharacterSubrace> parsed_character_subraces;
     // mutexes used to control the access to each of the content type maps
     std::unordered_map<ParsingType, std::mutex> parsing_mutexes;
     void resetParsed();

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -24,23 +24,21 @@ class ContentParser {
 private:
     static const std::unordered_map<ParsingType, std::string> subdir_names;
     std::unordered_map<std::string, std::shared_ptr<const Spell>> parsed_spells;
-    std::unordered_map<std::string, std::shared_ptr<Character>> parsed_characters;
+    std::unordered_map<std::string, std::unique_ptr<Character>> parsed_characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> parsed_character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> parsed_character_subraces;
     // mutexes used to control the access to each of the content type maps
     std::unordered_map<ParsingType, std::mutex> parsing_mutexes;
+    void resetParsed();
     void parseFileOfType(const ParsingType parsing_type, const std::filesystem::directory_entry& file);
-    // parse all files containing a certain content type in the provided directories
     void parseAllOfType(
         const ParsingType parsing_type, const std::vector<std::filesystem::directory_entry>& dirs_to_parse
     );
     std::unique_ptr<ContentFileParser> createParser(const ParsingType parsing_type);
 public:
-    // delete all the parsed content
-    void reset();
-    // parsing content from content_path for campaign cumulatively (use the reset function if you don't want that)
+    // parsing content from content_path for a certain campaign
     Content parse(const std::filesystem::path& content_path, const std::string& campaign_dir_name);
 };
 

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -27,7 +27,7 @@ private:
     std::unordered_map<std::string, Character> parsed_characters;
     std::unordered_map<std::string, const CharacterClass> parsed_character_classes;
     std::unordered_map<std::string, const CharacterSubclass> parsed_character_subclasses;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;
+    std::unordered_map<std::string, const CharacterRace> parsed_character_races;
     std::unordered_map<std::string, const CharacterSubrace> parsed_character_subraces;
     // mutexes used to control the access to each of the content type maps
     std::unordered_map<ParsingType, std::mutex> parsing_mutexes;

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -24,7 +24,7 @@ class ContentParser {
 private:
     static const std::unordered_map<ParsingType, std::string> subdir_names;
     std::unordered_map<std::string, const Spell> parsed_spells;
-    std::unordered_map<std::string, std::unique_ptr<Character>> parsed_characters;
+    std::unordered_map<std::string, Character> parsed_characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> parsed_character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -23,12 +23,12 @@ namespace dnd {
 class ContentParser {
 private:
     static const std::unordered_map<ParsingType, std::string> subdir_names;
-    std::unordered_map<std::string, const Spell> parsed_spells;
     std::unordered_map<std::string, Character> parsed_characters;
     std::unordered_map<std::string, const CharacterClass> parsed_character_classes;
     std::unordered_map<std::string, const CharacterSubclass> parsed_character_subclasses;
     std::unordered_map<std::string, const CharacterRace> parsed_character_races;
     std::unordered_map<std::string, const CharacterSubrace> parsed_character_subraces;
+    std::unordered_map<std::string, const Spell> parsed_spells;
     // mutexes used to control the access to each of the content type maps
     std::unordered_map<ParsingType, std::mutex> parsing_mutexes;
     void resetParsed();

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -31,7 +31,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> parsed_character_subraces;
     // mutexes used to control the access to each of the content type maps
     std::unordered_map<ParsingType, std::mutex> parsing_mutexes;
-    void parseSingleOfType(const ParsingType parsing_type, const std::filesystem::directory_entry* file);
+    void parseFileOfType(const ParsingType parsing_type, const std::filesystem::directory_entry& file);
     // parse all files containing a certain content type in the provided directories
     void parseAllOfType(
         const ParsingType parsing_type, const std::vector<std::filesystem::directory_entry>& dirs_to_parse

--- a/src/parsing/content_parser.hpp
+++ b/src/parsing/content_parser.hpp
@@ -26,7 +26,7 @@ private:
     std::unordered_map<std::string, const Spell> parsed_spells;
     std::unordered_map<std::string, Character> parsed_characters;
     std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> parsed_character_classes;
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> parsed_character_subclasses;
+    std::unordered_map<std::string, const CharacterSubclass> parsed_character_subclasses;
     std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> parsed_character_races;
     std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> parsed_character_subraces;
     // mutexes used to control the access to each of the content type maps

--- a/src/parsing/models/character_class_file_parser.cpp
+++ b/src/parsing/models/character_class_file_parser.cpp
@@ -34,14 +34,14 @@ void dnd::CharacterClassFileParser::parse() {
     }
 
     const Feature* subclass_feature = nullptr;
-    for (auto it = features.cbegin(); it != features.cend(); ++it) {
-        if ((*it)->subclass) {
+    for (const auto& feature : features) {
+        if (feature.subclass) {
             if (subclass_feature != nullptr) {
                 throw invalid_attribute(
                     ParsingType::CLASS, filename, "features", "there must be only one subclass feature."
                 );
             }
-            subclass_feature = it->get();
+            subclass_feature = &feature;
         }
     }
     if (subclass_feature == nullptr) {

--- a/src/parsing/models/character_class_file_parser.cpp
+++ b/src/parsing/models/character_class_file_parser.cpp
@@ -69,8 +69,9 @@ bool dnd::CharacterClassFileParser::validate() const {
 
 void dnd::CharacterClassFileParser::saveResult() {
     // TODO: change CharacterClass constructor
-    auto character_class =
-        std::make_shared<CharacterClass>(character_class_name, character_class_hit_dice, asi_levels, subclass_level);
-    character_class->features = std::move(features);
-    results.emplace(character_class_name, std::move(character_class));
+    results.emplace(
+        std::piecewise_construct, std::forward_as_tuple(character_class_name),
+        std::forward_as_tuple(character_class_name, character_class_hit_dice, asi_levels, subclass_level)
+    );
+    // TODO: add features
 }

--- a/src/parsing/models/character_class_file_parser.hpp
+++ b/src/parsing/models/character_class_file_parser.hpp
@@ -27,7 +27,7 @@ public:
 
 inline CharacterClassFileParser::CharacterClassFileParser(std::unordered_map<std::string, const CharacterClass>& results
 )
-    : results(results) {}
+    : FeatureHolderFileParser(), results(results) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_class_file_parser.hpp
+++ b/src/parsing/models/character_class_file_parser.hpp
@@ -14,19 +14,18 @@ namespace dnd {
 
 class CharacterClassFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& results;
+    std::unordered_map<std::string, const CharacterClass>& results;
     std::string character_class_name, character_class_hit_dice;
     std::vector<int> asi_levels;
     int subclass_level;
 public:
-    CharacterClassFileParser(std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& results);
+    CharacterClassFileParser(std::unordered_map<std::string, const CharacterClass>& results);
     void parse() override;
     bool validate() const override;
     void saveResult() override;
 };
 
-inline CharacterClassFileParser::CharacterClassFileParser(
-    std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& results
+inline CharacterClassFileParser::CharacterClassFileParser(std::unordered_map<std::string, const CharacterClass>& results
 )
     : results(results) {}
 

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -84,7 +84,7 @@ void dnd::CharacterFileParser::parseLevelAndXP() {
 void dnd::CharacterFileParser::parseClassAndRace() {
     const std::string character_class_name = json_to_parse.at("class").get<std::string>();
     try {
-        class_ptr = character_classes.at(character_class_name).get();
+        class_ptr = &character_classes.at(character_class_name);
     } catch (const std::out_of_range& e) {
         throw invalid_attribute(ParsingType::CHARACTER, filename, "class", "does not exist");
     }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -34,6 +34,8 @@ void dnd::CharacterFileParser::parse() {
     parseLevelAndXP();
     parseClassAndRace();
 
+    // TODO: parse spells
+
     if (json_to_parse.contains("features")) {
         try {
             parseFeatures();

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -125,7 +125,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
         }
         const std::string character_subrace_name = json_to_parse.at("subrace").get<std::string>();
         try {
-            subrace_ptr = character_subraces.at(character_subrace_name).get();
+            subrace_ptr = &character_subraces.at(character_subrace_name);
         } catch (const std::out_of_range& e) {
             throw invalid_attribute(ParsingType::CHARACTER, filename, "subrace", "does not exist");
         }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -160,7 +160,7 @@ void dnd::CharacterFileParser::saveResult() {
         std::forward_as_tuple(character_name, base_ability_scores, level, xp, hit_dice_rolls)
     );
     Character& character = results.at(character_name);
-    character.features = features;
+    character.features = std::move(features);
     character.race_ptr = race_ptr;
     character.subrace_ptr = subrace_ptr;
     character.class_ptr = class_ptr;

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -92,7 +92,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
     if (json_to_parse.contains("subclass")) {
         const std::string character_subclass_name = json_to_parse.at("subclass").get<std::string>();
         try {
-            subclass_ptr = character_subclasses.at(character_subclass_name).get();
+            subclass_ptr = &character_subclasses.at(character_subclass_name);
         } catch (const std::out_of_range& e) {
             throw invalid_attribute(ParsingType::CHARACTER, filename, "subclass", "does not exist");
         }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -148,12 +148,13 @@ bool dnd::CharacterFileParser::validate() const {
 void dnd::CharacterFileParser::saveResult() {
     // TODO: change Character constructor
     results.emplace(
-        character_name, std::make_unique<Character>(character_name, base_ability_scores, level, xp, hit_dice_rolls)
+        std::piecewise_construct, std::forward_as_tuple(character_name),
+        std::forward_as_tuple(character_name, base_ability_scores, level, xp, hit_dice_rolls)
     );
-    Character* character_ptr = results.at(character_name).get();
-    character_ptr->features = features;
-    character_ptr->race_ptr = race_ptr;
-    character_ptr->subrace_ptr = subrace_ptr;
-    character_ptr->class_ptr = class_ptr;
-    character_ptr->subclass_ptr = subclass_ptr;
+    Character& character = results.at(character_name);
+    character.features = features;
+    character.race_ptr = race_ptr;
+    character.subrace_ptr = subrace_ptr;
+    character.class_ptr = class_ptr;
+    character.subclass_ptr = subclass_ptr;
 }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -145,11 +145,13 @@ bool dnd::CharacterFileParser::validate() const {
 
 void dnd::CharacterFileParser::saveResult() {
     // TODO: change Character constructor
-    auto character = std::make_shared<Character>(character_name, base_ability_scores, level, xp, hit_dice_rolls);
-    character->features = features;
-    character->race_ptr = race_ptr;
-    character->subrace_ptr = subrace_ptr;
-    character->class_ptr = class_ptr;
-    character->subclass_ptr = subclass_ptr;
-    results.emplace(character_name, std::move(character));
+    results.emplace(
+        character_name, std::make_unique<Character>(character_name, base_ability_scores, level, xp, hit_dice_rolls)
+    );
+    Character* character_ptr = results.at(character_name).get();
+    character_ptr->features = features;
+    character_ptr->race_ptr = race_ptr;
+    character_ptr->subrace_ptr = subrace_ptr;
+    character_ptr->class_ptr = class_ptr;
+    character_ptr->subclass_ptr = subclass_ptr;
 }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -86,7 +86,9 @@ void dnd::CharacterFileParser::parseClassAndRace() {
     try {
         class_ptr = &character_classes.at(character_class_name);
     } catch (const std::out_of_range& e) {
-        throw invalid_attribute(ParsingType::CHARACTER, filename, "class", "does not exist");
+        throw invalid_attribute(
+            ParsingType::CHARACTER, filename, "class", '\"' + character_class_name + "\" does not exist"
+        );
     }
 
     if (json_to_parse.contains("subclass")) {
@@ -94,7 +96,9 @@ void dnd::CharacterFileParser::parseClassAndRace() {
         try {
             subclass_ptr = &character_subclasses.at(character_subclass_name);
         } catch (const std::out_of_range& e) {
-            throw invalid_attribute(ParsingType::CHARACTER, filename, "subclass", "does not exist");
+            throw invalid_attribute(
+                ParsingType::CHARACTER, filename, "subclass", '\"' + character_subclass_name + "\" does not exist"
+            );
         }
         if (class_ptr->subclass_level > level) {
             std::cerr << "Warning: Character " << character_name << " has subclass although the class \""
@@ -113,7 +117,9 @@ void dnd::CharacterFileParser::parseClassAndRace() {
     try {
         race_ptr = &character_races.at(character_race_name);
     } catch (const std::out_of_range& e) {
-        throw invalid_attribute(ParsingType::CHARACTER, filename, "race", "does not exist");
+        throw invalid_attribute(
+            ParsingType::CHARACTER, filename, "race", '\"' + character_race_name + "\" does not exist"
+        );
     }
 
     if (json_to_parse.contains("subrace")) {
@@ -127,7 +133,9 @@ void dnd::CharacterFileParser::parseClassAndRace() {
         try {
             subrace_ptr = &character_subraces.at(character_subrace_name);
         } catch (const std::out_of_range& e) {
-            throw invalid_attribute(ParsingType::CHARACTER, filename, "subrace", "does not exist");
+            throw invalid_attribute(
+                ParsingType::CHARACTER, filename, "subrace", '\"' + character_subrace_name + "\" does not exist"
+            );
         }
     } else if (race_ptr->has_subraces) {
         std::cout << "JSON:\n" << json_to_parse << std::endl;

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -82,7 +82,7 @@ void dnd::CharacterFileParser::parseLevelAndXP() {
 void dnd::CharacterFileParser::parseClassAndRace() {
     const std::string character_class_name = json_to_parse.at("class").get<std::string>();
     try {
-        class_ptr = character_classes.at(character_class_name);
+        class_ptr = character_classes.at(character_class_name).get();
     } catch (const std::out_of_range& e) {
         throw invalid_attribute(ParsingType::CHARACTER, filename, "class", "does not exist");
     }
@@ -90,7 +90,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
     if (json_to_parse.contains("subclass")) {
         const std::string character_subclass_name = json_to_parse.at("subclass").get<std::string>();
         try {
-            subclass_ptr = character_subclasses.at(character_subclass_name);
+            subclass_ptr = character_subclasses.at(character_subclass_name).get();
         } catch (const std::out_of_range& e) {
             throw invalid_attribute(ParsingType::CHARACTER, filename, "subclass", "does not exist");
         }
@@ -109,7 +109,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
 
     const std::string character_race_name = json_to_parse.at("race").get<std::string>();
     try {
-        race_ptr = character_races.at(character_race_name);
+        race_ptr = character_races.at(character_race_name).get();
     } catch (const std::out_of_range& e) {
         throw invalid_attribute(ParsingType::CHARACTER, filename, "race", "does not exist");
     }
@@ -123,7 +123,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
         }
         const std::string character_subrace_name = json_to_parse.at("subrace").get<std::string>();
         try {
-            subrace_ptr = character_subraces.at(character_subrace_name);
+            subrace_ptr = character_subraces.at(character_subrace_name).get();
         } catch (const std::out_of_range& e) {
             throw invalid_attribute(ParsingType::CHARACTER, filename, "subrace", "does not exist");
         }

--- a/src/parsing/models/character_file_parser.cpp
+++ b/src/parsing/models/character_file_parser.cpp
@@ -111,7 +111,7 @@ void dnd::CharacterFileParser::parseClassAndRace() {
 
     const std::string character_race_name = json_to_parse.at("race").get<std::string>();
     try {
-        race_ptr = character_races.at(character_race_name).get();
+        race_ptr = &character_races.at(character_race_name);
     } catch (const std::out_of_range& e) {
         throw invalid_attribute(ParsingType::CHARACTER, filename, "race", "does not exist");
     }

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -20,11 +20,11 @@ namespace dnd {
 class CharacterFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, std::unique_ptr<Character>>& results;
-    const std::unordered_map<std::string, std::shared_ptr<const Spell>>& spells;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> character_subraces;
+    const std::unordered_map<std::string, const Spell>& spells;
     std::string character_name;
     std::array<int, 6> base_ability_scores;
     std::vector<int> hit_dice_rolls;
@@ -42,7 +42,7 @@ public:
         const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
-        const std::unordered_map<std::string, std::shared_ptr<const Spell>>& spells
+        const std::unordered_map<std::string, const Spell>& spells
     );
     void parse() override;
     bool validate() const override;
@@ -55,7 +55,7 @@ inline CharacterFileParser::CharacterFileParser(
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
-    const std::unordered_map<std::string, std::shared_ptr<const Spell>>& spells
+    const std::unordered_map<std::string, const Spell>& spells
 )
     : results(results), character_classes(character_classes), character_subclasses(character_subclasses),
       character_races(character_races), character_subraces(character_subraces), spells(spells) {}

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -19,7 +19,7 @@ namespace dnd {
 
 class CharacterFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<Character>>& results;
+    std::unordered_map<std::string, std::unique_ptr<Character>>& results;
     const std::unordered_map<std::string, std::shared_ptr<const Spell>>& spells;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
@@ -37,7 +37,7 @@ private:
     void parseLevelAndXP();
 public:
     CharacterFileParser(
-        std::unordered_map<std::string, std::shared_ptr<Character>>& results,
+        std::unordered_map<std::string, std::unique_ptr<Character>>& results,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
@@ -50,7 +50,7 @@ public:
 };
 
 inline CharacterFileParser::CharacterFileParser(
-    std::unordered_map<std::string, std::shared_ptr<Character>>& results,
+    std::unordered_map<std::string, std::unique_ptr<Character>>& results,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -20,10 +20,10 @@ namespace dnd {
 class CharacterFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, Character>& results;
-    const std::unordered_map<std::string, const CharacterClass> character_classes;
-    const std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
-    const std::unordered_map<std::string, const CharacterRace> character_races;
-    const std::unordered_map<std::string, const CharacterSubrace> character_subraces;
+    const std::unordered_map<std::string, const CharacterClass>& character_classes;
+    const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses;
+    const std::unordered_map<std::string, const CharacterRace>& character_races;
+    const std::unordered_map<std::string, const CharacterSubrace>& character_subraces;
     const std::unordered_map<std::string, const Spell>& spells;
     std::string character_name;
     std::array<int, 6> base_ability_scores;

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -28,10 +28,10 @@ private:
     std::string character_name;
     std::array<int, 6> base_ability_scores;
     std::vector<int> hit_dice_rolls;
-    std::shared_ptr<const CharacterClass> class_ptr;
-    std::shared_ptr<const CharacterSubclass> subclass_ptr;
-    std::shared_ptr<const CharacterRace> race_ptr;
-    std::shared_ptr<const CharacterSubrace> subrace_ptr;
+    const CharacterClass* class_ptr;
+    const CharacterSubclass* subclass_ptr;
+    const CharacterRace* race_ptr;
+    const CharacterSubrace* subrace_ptr;
     int level, xp;
     void parseClassAndRace();
     void parseLevelAndXP();

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -19,7 +19,7 @@ namespace dnd {
 
 class CharacterFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::unique_ptr<Character>>& results;
+    std::unordered_map<std::string, Character>& results;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
@@ -37,7 +37,7 @@ private:
     void parseLevelAndXP();
 public:
     CharacterFileParser(
-        std::unordered_map<std::string, std::unique_ptr<Character>>& results,
+        std::unordered_map<std::string, Character>& results,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
@@ -50,7 +50,7 @@ public:
 };
 
 inline CharacterFileParser::CharacterFileParser(
-    std::unordered_map<std::string, std::unique_ptr<Character>>& results,
+    std::unordered_map<std::string, Character>& results,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -23,7 +23,7 @@ private:
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
     const std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> character_subraces;
+    const std::unordered_map<std::string, const CharacterSubrace> character_subraces;
     const std::unordered_map<std::string, const Spell>& spells;
     std::string character_name;
     std::array<int, 6> base_ability_scores;
@@ -41,7 +41,7 @@ public:
         const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
         const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
+        const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
         const std::unordered_map<std::string, const Spell>& spells
     );
     void parse() override;
@@ -54,7 +54,7 @@ inline CharacterFileParser::CharacterFileParser(
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
     const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
+    const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
     const std::unordered_map<std::string, const Spell>& spells
 )
     : results(results), character_classes(character_classes), character_subclasses(character_subclasses),

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -20,7 +20,7 @@ namespace dnd {
 class CharacterFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, Character>& results;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
+    const std::unordered_map<std::string, const CharacterClass> character_classes;
     const std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
     const std::unordered_map<std::string, const CharacterSubrace> character_subraces;
@@ -38,7 +38,7 @@ private:
 public:
     CharacterFileParser(
         std::unordered_map<std::string, Character>& results,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
+        const std::unordered_map<std::string, const CharacterClass>& character_classes,
         const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
         const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
@@ -51,7 +51,7 @@ public:
 
 inline CharacterFileParser::CharacterFileParser(
     std::unordered_map<std::string, Character>& results,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
+    const std::unordered_map<std::string, const CharacterClass>& character_classes,
     const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
     const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -57,8 +57,9 @@ inline CharacterFileParser::CharacterFileParser(
     const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
     const std::unordered_map<std::string, const Spell>& spells
 )
-    : results(results), character_classes(character_classes), character_subclasses(character_subclasses),
-      character_races(character_races), character_subraces(character_subraces), spells(spells) {}
+    : FeatureHolderFileParser(), results(results), character_classes(character_classes),
+      character_subclasses(character_subclasses), character_races(character_races),
+      character_subraces(character_subraces), spells(spells) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -21,7 +21,7 @@ class CharacterFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, Character>& results;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>> character_classes;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>> character_subclasses;
+    const std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>> character_subraces;
     const std::unordered_map<std::string, const Spell>& spells;
@@ -39,7 +39,7 @@ public:
     CharacterFileParser(
         std::unordered_map<std::string, Character>& results,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
+        const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
         const std::unordered_map<std::string, const Spell>& spells
@@ -52,7 +52,7 @@ public:
 inline CharacterFileParser::CharacterFileParser(
     std::unordered_map<std::string, Character>& results,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& character_classes,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& character_subclasses,
+    const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& character_subraces,
     const std::unordered_map<std::string, const Spell>& spells

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -22,7 +22,7 @@ private:
     std::unordered_map<std::string, Character>& results;
     const std::unordered_map<std::string, const CharacterClass> character_classes;
     const std::unordered_map<std::string, const CharacterSubclass> character_subclasses;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>> character_races;
+    const std::unordered_map<std::string, const CharacterRace> character_races;
     const std::unordered_map<std::string, const CharacterSubrace> character_subraces;
     const std::unordered_map<std::string, const Spell>& spells;
     std::string character_name;
@@ -40,7 +40,7 @@ public:
         std::unordered_map<std::string, Character>& results,
         const std::unordered_map<std::string, const CharacterClass>& character_classes,
         const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
+        const std::unordered_map<std::string, const CharacterRace>& character_races,
         const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
         const std::unordered_map<std::string, const Spell>& spells
     );
@@ -53,7 +53,7 @@ inline CharacterFileParser::CharacterFileParser(
     std::unordered_map<std::string, Character>& results,
     const std::unordered_map<std::string, const CharacterClass>& character_classes,
     const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& character_races,
+    const std::unordered_map<std::string, const CharacterRace>& character_races,
     const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
     const std::unordered_map<std::string, const Spell>& spells
 )

--- a/src/parsing/models/character_race_file_parser.cpp
+++ b/src/parsing/models/character_race_file_parser.cpp
@@ -42,7 +42,9 @@ bool dnd::CharacterRaceFileParser::validate() const {
 
 void dnd::CharacterRaceFileParser::saveResult() {
     // TODO: change CharacterRace constructor
-    auto character_race = std::make_shared<CharacterRace>(character_race_name, has_subraces);
-    character_race->features = std::move(features);
-    results.emplace(character_race_name, std::move(character_race));
+    results.emplace(
+        std::piecewise_construct, std::forward_as_tuple(character_race_name),
+        std::forward_as_tuple(character_race_name, has_subraces)
+    );
+    // TODO: add features
 }

--- a/src/parsing/models/character_race_file_parser.hpp
+++ b/src/parsing/models/character_race_file_parser.hpp
@@ -25,7 +25,7 @@ public:
 };
 
 inline CharacterRaceFileParser::CharacterRaceFileParser(std::unordered_map<std::string, const CharacterRace>& results)
-    : results(results) {}
+    : FeatureHolderFileParser(), results(results) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_race_file_parser.hpp
+++ b/src/parsing/models/character_race_file_parser.hpp
@@ -14,20 +14,18 @@ namespace dnd {
 
 class CharacterRaceFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& results;
+    std::unordered_map<std::string, const CharacterRace>& results;
     std::string character_race_name;
     bool has_subraces;
     std::vector<std::shared_ptr<const Feature>> features;
 public:
-    CharacterRaceFileParser(std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& results);
+    CharacterRaceFileParser(std::unordered_map<std::string, const CharacterRace>& results);
     void parse() override;
     bool validate() const override;
     void saveResult() override;
 };
 
-inline CharacterRaceFileParser::CharacterRaceFileParser(
-    std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& results
-)
+inline CharacterRaceFileParser::CharacterRaceFileParser(std::unordered_map<std::string, const CharacterRace>& results)
     : results(results) {}
 
 } // namespace dnd

--- a/src/parsing/models/character_race_file_parser.hpp
+++ b/src/parsing/models/character_race_file_parser.hpp
@@ -17,7 +17,6 @@ private:
     std::unordered_map<std::string, const CharacterRace>& results;
     std::string character_race_name;
     bool has_subraces;
-    std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterRaceFileParser(std::unordered_map<std::string, const CharacterRace>& results);
     void parse() override;

--- a/src/parsing/models/character_subclass_file_parser.cpp
+++ b/src/parsing/models/character_subclass_file_parser.cpp
@@ -47,7 +47,9 @@ bool dnd::CharacterSubclassFileParser::validate() const {
 
 void dnd::CharacterSubclassFileParser::saveResult() {
     // TODO: change CharacterSubclass constructor
-    auto character_subclass = std::make_shared<CharacterSubclass>(character_subclass_name, class_name);
-    character_subclass->features = std::move(features);
-    results.emplace(character_subclass_name, std::move(character_subclass));
+    results.emplace(
+        std::piecewise_construct, std::forward_as_tuple(character_subclass_name),
+        std::forward_as_tuple(character_subclass_name, class_name)
+    );
+    // TODO: add features
 }

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -17,7 +17,6 @@ private:
     std::unordered_map<std::string, const CharacterSubclass>& results;
     const std::unordered_map<std::string, const CharacterClass>& classes;
     std::string character_subclass_name, class_name;
-    std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubclassFileParser(
         std::unordered_map<std::string, const CharacterSubclass>& results,

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -15,13 +15,13 @@ namespace dnd {
 class CharacterSubclassFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, const CharacterSubclass>& results;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes;
+    const std::unordered_map<std::string, const CharacterClass>& classes;
     std::string character_subclass_name, class_name;
     std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubclassFileParser(
         std::unordered_map<std::string, const CharacterSubclass>& results,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes
+        const std::unordered_map<std::string, const CharacterClass>& classes
     );
     void parse() override;
     bool validate() const override;
@@ -30,7 +30,7 @@ public:
 
 inline CharacterSubclassFileParser::CharacterSubclassFileParser(
     std::unordered_map<std::string, const CharacterSubclass>& results,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes
+    const std::unordered_map<std::string, const CharacterClass>& classes
 )
     : results(results), classes(classes) {}
 

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -31,7 +31,7 @@ inline CharacterSubclassFileParser::CharacterSubclassFileParser(
     std::unordered_map<std::string, const CharacterSubclass>& results,
     const std::unordered_map<std::string, const CharacterClass>& classes
 )
-    : results(results), classes(classes) {}
+    : FeatureHolderFileParser(), results(results), classes(classes) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -14,13 +14,13 @@ namespace dnd {
 
 class CharacterSubclassFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& results;
+    std::unordered_map<std::string, const CharacterSubclass>& results;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes;
     std::string character_subclass_name, class_name;
     std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubclassFileParser(
-        std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& results,
+        std::unordered_map<std::string, const CharacterSubclass>& results,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes
     );
     void parse() override;
@@ -29,7 +29,7 @@ public:
 };
 
 inline CharacterSubclassFileParser::CharacterSubclassFileParser(
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubclass>>& results,
+    std::unordered_map<std::string, const CharacterSubclass>& results,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterClass>>& classes
 )
     : results(results), classes(classes) {}

--- a/src/parsing/models/character_subrace_file_parser.cpp
+++ b/src/parsing/models/character_subrace_file_parser.cpp
@@ -42,7 +42,7 @@ bool dnd::CharacterSubraceFileParser::validate() const {
             ParsingType::SUBRACE, filename, "race", "must exist. \"" + race_name + "\" does not exist."
         );
     }
-    if (!races.at(race_name)->has_subraces) {
+    if (!races.at(race_name).has_subraces) {
         throw invalid_attribute(
             ParsingType::SUBRACE, filename, "race", "must have subraces. \"" + race_name + "\" does not have subraces."
         );

--- a/src/parsing/models/character_subrace_file_parser.cpp
+++ b/src/parsing/models/character_subrace_file_parser.cpp
@@ -52,7 +52,9 @@ bool dnd::CharacterSubraceFileParser::validate() const {
 
 void dnd::CharacterSubraceFileParser::saveResult() {
     // TODO: change CharacterSubrace constructor
-    auto character_subrace = std::make_shared<CharacterSubrace>(character_subrace_name, race_name);
-    character_subrace->features = std::move(features);
-    results.emplace(character_subrace_name, std::move(character_subrace));
+    results.emplace(
+        std::piecewise_construct, std::forward_as_tuple(character_subrace_name),
+        std::forward_as_tuple(character_subrace_name, race_name)
+    );
+    // TODO: add features
 }

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -15,13 +15,13 @@ namespace dnd {
 class CharacterSubraceFileParser : public FeatureHolderFileParser {
 private:
     std::unordered_map<std::string, const CharacterSubrace>& results;
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races;
+    const std::unordered_map<std::string, const CharacterRace>& races;
     std::string character_subrace_name, race_name;
     std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubraceFileParser(
         std::unordered_map<std::string, const CharacterSubrace>& results,
-        const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races
+        const std::unordered_map<std::string, const CharacterRace>& races
     );
     void parse() override;
     bool validate() const override;
@@ -30,7 +30,7 @@ public:
 
 inline CharacterSubraceFileParser::CharacterSubraceFileParser(
     std::unordered_map<std::string, const CharacterSubrace>& results,
-    const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races
+    const std::unordered_map<std::string, const CharacterRace>& races
 )
     : results(results), races(races) {}
 

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -14,13 +14,13 @@ namespace dnd {
 
 class CharacterSubraceFileParser : public FeatureHolderFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& results;
+    std::unordered_map<std::string, const CharacterSubrace>& results;
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races;
     std::string character_subrace_name, race_name;
     std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubraceFileParser(
-        std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& results,
+        std::unordered_map<std::string, const CharacterSubrace>& results,
         const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races
     );
     void parse() override;
@@ -29,7 +29,7 @@ public:
 };
 
 inline CharacterSubraceFileParser::CharacterSubraceFileParser(
-    std::unordered_map<std::string, std::shared_ptr<const CharacterSubrace>>& results,
+    std::unordered_map<std::string, const CharacterSubrace>& results,
     const std::unordered_map<std::string, std::shared_ptr<const CharacterRace>>& races
 )
     : results(results), races(races) {}

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -31,7 +31,7 @@ inline CharacterSubraceFileParser::CharacterSubraceFileParser(
     std::unordered_map<std::string, const CharacterSubrace>& results,
     const std::unordered_map<std::string, const CharacterRace>& races
 )
-    : results(results), races(races) {}
+    : FeatureHolderFileParser(), results(results), races(races) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -17,7 +17,6 @@ private:
     std::unordered_map<std::string, const CharacterSubrace>& results;
     const std::unordered_map<std::string, const CharacterRace>& races;
     std::string character_subrace_name, race_name;
-    std::vector<std::shared_ptr<const Feature>> features;
 public:
     CharacterSubraceFileParser(
         std::unordered_map<std::string, const CharacterSubrace>& results,

--- a/src/parsing/models/feature_holder_file_parser.cpp
+++ b/src/parsing/models/feature_holder_file_parser.cpp
@@ -28,7 +28,7 @@ void dnd::FeatureHolderFileParser::parseFeatures() {
     }
 }
 
-std::shared_ptr<dnd::Feature> dnd::FeatureHolderFileParser::createFeature(
+dnd::Feature dnd::FeatureHolderFileParser::createFeature(
     const std::string& feature_name, const nlohmann::json& feature_json
 ) const {
     if (!feature_json.is_object()) {
@@ -70,7 +70,7 @@ std::shared_ptr<dnd::Feature> dnd::FeatureHolderFileParser::createFeature(
             parseAndAddEffect(effect_str, feature);
         }
     }
-    return std::make_shared<Feature>(std::move(feature));
+    return feature;
 }
 
 void dnd::FeatureHolderFileParser::parseAndAddEffect(const std::string& effect_str, dnd::Feature& feature) const {
@@ -137,9 +137,9 @@ void dnd::FeatureHolderFileParser::parseAndAddEffect(const std::string& effect_s
 
     const EffectTime effect_time = effect_time_for_string.at(effect_time_str);
     if (CreatureState::isAbility(affected_attribute)) {
-        feature.ability_score_effects[effect_time].push_back(std::move(effect_ptr));
+        feature.ability_score_effects[effect_time].emplace_back(std::move(effect_ptr));
     } else {
-        feature.normal_effects[effect_time].push_back(std::move(effect_ptr));
+        feature.normal_effects[effect_time].emplace_back(std::move(effect_ptr));
     }
 }
 

--- a/src/parsing/models/feature_holder_file_parser.hpp
+++ b/src/parsing/models/feature_holder_file_parser.hpp
@@ -15,10 +15,10 @@ namespace dnd {
 
 class FeatureHolderFileParser : public ContentFileParser {
 protected:
-    std::vector<std::shared_ptr<const Feature>> features;
+    std::vector<Feature> features;
     void parseAndAddEffect(const std::string& effect_str, Feature& feature) const;
     void parseAndAddActivation(const std::string& activation_str, Feature& feature) const;
-    std::shared_ptr<Feature> createFeature(const std::string& feature_name, const nlohmann::json& feature_json) const;
+    Feature createFeature(const std::string& feature_name, const nlohmann::json& feature_json) const;
     virtual void parseFeatures();
 public:
     FeatureHolderFileParser() = default;

--- a/src/parsing/models/feature_holder_file_parser.hpp
+++ b/src/parsing/models/feature_holder_file_parser.hpp
@@ -20,6 +20,8 @@ protected:
     void parseAndAddActivation(const std::string& activation_str, Feature& feature) const;
     std::shared_ptr<Feature> createFeature(const std::string& feature_name, const nlohmann::json& feature_json) const;
     virtual void parseFeatures();
+public:
+    FeatureHolderFileParser() = default;
 };
 
 } // namespace dnd

--- a/src/parsing/models/spells_file_parser.cpp
+++ b/src/parsing/models/spells_file_parser.cpp
@@ -17,16 +17,16 @@
 #include "parsing/parsing_types.hpp"
 
 
-void dnd::SpellsFileParser::createSpell(std::string_view spell_name, nlohmann::json* spell_json_ptr) {
+void dnd::SpellsFileParser::createSpell(std::string_view spell_name, const nlohmann::json& spell_json_ptr) {
     DND_MEASURE_FUNCTION();
     SpellParsingInfo info;
     info.name = spell_name;
-    info.casting_time = spell_json_ptr->at("casting_time").get<std::string>();
-    info.range = spell_json_ptr->at("range").get<std::string>();
-    info.duration = spell_json_ptr->at("duration").get<std::string>();
-    info.description = spell_json_ptr->at("description").get<std::string>();
-    info.type = createSpellType(spell_json_ptr->at("level_type").get<std::string>());
-    info.components = createSpellComponents(spell_json_ptr->at("components").get<std::string>());
+    info.casting_time = spell_json_ptr.at("casting_time").get<std::string>();
+    info.range = spell_json_ptr.at("range").get<std::string>();
+    info.duration = spell_json_ptr.at("duration").get<std::string>();
+    info.description = spell_json_ptr.at("description").get<std::string>();
+    info.type = createSpellType(spell_json_ptr.at("level_type").get<std::string>());
+    info.components = createSpellComponents(spell_json_ptr.at("components").get<std::string>());
     std::lock_guard<std::mutex> lock(spell_parsing_mutex);
     spell_parsing_info.emplace_back(std::move(info));
 }
@@ -45,7 +45,7 @@ void dnd::SpellsFileParser::parse() {
             throw invalid_attribute(ParsingType::SPELL, filename, "spell name", "cannot be \"\".");
         }
         futures.emplace_back(
-            std::async(std::launch::async, &SpellsFileParser::createSpell, this, spell_name, &spell_json)
+            std::async(std::launch::async, &SpellsFileParser::createSpell, this, spell_name, spell_json)
         );
     }
     for (auto& future : futures) {

--- a/src/parsing/models/spells_file_parser.cpp
+++ b/src/parsing/models/spells_file_parser.cpp
@@ -141,10 +141,13 @@ void dnd::SpellsFileParser::saveResult() {
     for (int i = 0; i < spells_in_file; ++i) {
         if (valid[i]) {
             SpellParsingInfo& info = spell_parsing_info[i];
-            auto spell = std::make_unique<Spell>(
-                info.name, info.type, info.casting_time, info.range, info.components, info.duration, info.description
+            results.emplace(
+                std::piecewise_construct, std::forward_as_tuple(info.name),
+                std::forward_as_tuple(
+                    info.name, info.type, info.casting_time, info.range, info.components, info.duration,
+                    info.description
+                )
             );
-            results.emplace(info.name, std::move(spell));
         }
     }
 }

--- a/src/parsing/models/spells_file_parser.cpp
+++ b/src/parsing/models/spells_file_parser.cpp
@@ -59,12 +59,13 @@ void dnd::SpellsFileParser::parse() {
 
 dnd::SpellType dnd::SpellsFileParser::createSpellType(const std::string& spell_type_str) const {
     DND_MEASURE_FUNCTION();
-    const std::string magic_school_regex_str = "([aA]bjuration|[cC]onjuration|[dD]ivination|[eE]nchantment|"
-                                               "[eE]vocation|[iI]llusion|[nN]ecromancy|[tT]ransmutation)";
-    const std::regex spell_type_regex(
-        "((1st|2nd|3rd|[4-9]th)-level " + magic_school_regex_str + "( \\(ritual\\))?)|(" + magic_school_regex_str
-        + " cantrip)"
-    );
+    const std::regex spell_type_regex("((1st|2nd|3rd|[4-9]th)-level "
+                                      "([aA]bjuration|[cC]onjuration|[dD]ivination|[eE]nchantment|"
+                                      "[eE]vocation|[iI]llusion|[nN]ecromancy|[tT]ransmutation)"
+                                      "( \\(ritual\\))?)|("
+                                      "([aA]bjuration|[cC]onjuration|[dD]ivination|[eE]nchantment|"
+                                      "[eE]vocation|[iI]llusion|[nN]ecromancy|[tT]ransmutation)"
+                                      " cantrip)");
     if (!std::regex_match(spell_type_str, spell_type_regex)) {
         // TODO: think about how to reintroduce spell name into error message
         throw attribute_type_error(filename, "invalid spell type format: \"" + spell_type_str + "\"");

--- a/src/parsing/models/spells_file_parser.hpp
+++ b/src/parsing/models/spells_file_parser.hpp
@@ -29,7 +29,7 @@ private:
     mutable std::vector<bool> valid;
     std::mutex spell_parsing_mutex;
 protected:
-    void createSpell(std::string_view spell_name, nlohmann::json* spell_json_ptr);
+    void createSpell(std::string_view spell_name, const nlohmann::json& spell_json_ptr);
     SpellType createSpellType(const std::string& spell_type_str) const;
     SpellComponents createSpellComponents(const std::string& spell_components_str) const;
 public:

--- a/src/parsing/models/spells_file_parser.hpp
+++ b/src/parsing/models/spells_file_parser.hpp
@@ -23,7 +23,7 @@ struct SpellParsingInfo {
 
 class SpellsFileParser : public ContentFileParser {
 private:
-    std::unordered_map<std::string, std::shared_ptr<const Spell>>& results;
+    std::unordered_map<std::string, const Spell>& results;
     int spells_in_file;
     std::vector<SpellParsingInfo> spell_parsing_info;
     mutable std::vector<bool> valid;
@@ -33,14 +33,13 @@ protected:
     SpellType createSpellType(const std::string& spell_type_str) const;
     SpellComponents createSpellComponents(const std::string& spell_components_str) const;
 public:
-    SpellsFileParser(std::unordered_map<std::string, std::shared_ptr<const Spell>>& results);
+    SpellsFileParser(std::unordered_map<std::string, const Spell>& results);
     void parse() override;
     bool validate() const override;
     void saveResult() override;
 };
 
-inline SpellsFileParser::SpellsFileParser(std::unordered_map<std::string, std::shared_ptr<const Spell>>& results)
-    : results(results) {}
+inline SpellsFileParser::SpellsFileParser(std::unordered_map<std::string, const Spell>& results) : results(results) {}
 
 } // namespace dnd
 

--- a/src/parsing/parsing_exceptions.hpp
+++ b/src/parsing/parsing_exceptions.hpp
@@ -159,14 +159,14 @@ inline attribute_type_error::attribute_type_error(
 inline invalid_attribute::invalid_attribute(
     const std::filesystem::path& path, const std::string& attribute, const std::string& error_msg
 )
-    : parsing_error(path, "invalid attribute \"" + attribute + "\": " + error_msg) {}
+    : parsing_error(path, "has invalid attribute \"" + attribute + "\": " + error_msg) {}
 
 
 inline invalid_attribute::invalid_attribute(
     ParsingType parsing_type, const std::filesystem::path& path, const std::string& attribute,
     const std::string& error_msg
 )
-    : parsing_error(parsing_type, path, "invalid attribute \"" + attribute + "\": " + error_msg) {}
+    : parsing_error(parsing_type, path, "has invalid attribute \"" + attribute + "\": " + error_msg) {}
 
 
 } // namespace dnd

--- a/src/runtime_measurement/CMakeLists.txt
+++ b/src/runtime_measurement/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(dndmanager
+    PRIVATE
+        measurer.cpp
+)
+
+target_sources(dndmanager_tests
+    PRIVATE
+        measurer.cpp
+)

--- a/src/runtime_measurement/measurer.cpp
+++ b/src/runtime_measurement/measurer.cpp
@@ -1,0 +1,101 @@
+#include "dnd_config.hpp"
+
+#include "measurer.hpp"
+
+const std::vector<std::string> values_for_human_readable = {
+    "int dnd::launch(int, char**)",
+    "Main execution scope",
+    "dnd::Content dnd::ContentParser::parse(const std::filesystem::__cxx11::path&, const string&)",
+    "dnd::ContentParser::parseAllOfType ( spells )",
+    "dnd::ContentParser::parseAllOfType ( races )",
+    "dnd::ContentParser::parseAllOfType ( classes )",
+    "dnd::ContentParser::parseAllOfType ( subraces )",
+    "dnd::ContentParser::parseAllOfType ( subclasses )",
+    "dnd::ContentParser::parseAllOfType ( characters )",
+};
+
+void dnd::Measurer::beginSession(const std::string& name, const std::string& filepath = "results.json") {
+    session_start_time = std::chrono::high_resolution_clock::now();
+    session = new MeasuringSession{name, filepath, {{"traceEvents", nlohmann::json::array()}}};
+}
+
+void dnd::Measurer::endSession() {
+    auto session_end_time = std::chrono::high_resolution_clock::now();
+
+    // convert thread ids to consecutive integers
+    std::vector<size_t> thread_ids;
+    int next_id = 0;
+    for (auto& measurement : session->json.at("traceEvents")) {
+        auto it = find(thread_ids.begin(), thread_ids.end(), measurement.at("tid"));
+        if (it != thread_ids.end()) {
+            int idx = it - thread_ids.begin();
+            measurement.at("tid") = idx;
+        } else {
+            thread_ids.emplace_back(measurement.at("tid"));
+            measurement.at("tid") = next_id++;
+        }
+    }
+
+    // write some important values to a human readable file
+    output_stream.open(session->filepath + ".txt");
+    size_t max_str_len = 0;
+    for (const auto& value : values_for_human_readable) {
+        max_str_len = std::max(max_str_len, value.size());
+    }
+    max_str_len += 4;
+
+    auto start = std::chrono::system_clock::to_time_t(session_start_time);
+    output_stream << "Session started at: " << std::put_time(std::localtime(&start), "%F %T\n");
+    auto end = std::chrono::system_clock::to_time_t(session_end_time);
+    output_stream << "Session stopped at: " << std::put_time(std::localtime(&end), "%F %T\n\n");
+
+    for (const auto& human_readable_value : values_for_human_readable) {
+        for (auto& measurement : session->json.at("traceEvents")) {
+            if (measurement.at("name") == human_readable_value) {
+                output_stream << human_readable_value;
+                for (int i = 0; i < max_str_len - human_readable_value.size(); ++i) {
+                    output_stream << ' ';
+                }
+                output_stream << measurement.at("dur").get<int>() / 1000.0f << " ms\n";
+                break;
+            }
+        }
+    }
+    output_stream.flush();
+    output_stream.close();
+
+    output_stream.open(session->filepath);
+    output_stream << std::setw(4) << session->json << std::flush;
+    output_stream.close();
+    delete session;
+    session = nullptr;
+}
+
+void dnd::Measurer::writeProfile(const TimerResult& result) {
+    if (session == nullptr) {
+        return;
+    }
+    std::string name = result.name;
+    std::replace(name.begin(), name.end(), '"', '\'');
+
+    nlohmann::json result_json = {
+        {"cat", "function"}, {"dur", result.end - result.start}, {"name", name},       {"ph", "X"},
+        {"pid", 0},          {"tid", result.thread_id},          {"ts", result.start},
+    };
+
+    std::lock_guard<std::mutex> lock(write_profile_mutex);
+    session->json.at("traceEvents").push_back(result_json);
+}
+
+void dnd::Timer::stop() {
+    std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
+
+    long long start = std::chrono::time_point_cast<std::chrono::microseconds>(start_time).time_since_epoch().count();
+    long long end = std::chrono::time_point_cast<std::chrono::microseconds>(end_time).time_since_epoch().count();
+
+    size_t thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
+
+    Measurer::get().writeProfile({name, start, end, thread_id});
+
+    stopped = true;
+}

--- a/src/runtime_measurement/measurer.hpp
+++ b/src/runtime_measurement/measurer.hpp
@@ -28,6 +28,7 @@ struct MeasuringSession {
 class Measurer {
 private:
     MeasuringSession* session;
+    std::chrono::high_resolution_clock::time_point session_start_time;
     std::ofstream output_stream;
     static std::mutex write_profile_mutex;
 public:
@@ -54,53 +55,10 @@ inline std::mutex Measurer::write_profile_mutex;
 
 inline Measurer::Measurer() : session(nullptr) {}
 
-inline void Measurer::beginSession(const std::string& name, const std::string& filepath = "results.json") {
-    session = new MeasuringSession{name, filepath, {{"traceEvents", nlohmann::json::array()}}};
-}
-
-inline void Measurer::endSession() {
-    output_stream.open(session->filepath);
-    // convert thread ids to consecutive integers
-    std::vector<size_t> thread_ids;
-    int next_id = 0;
-    for (auto& measurement : session->json.at("traceEvents")) {
-        auto it = find(thread_ids.begin(), thread_ids.end(), measurement.at("tid"));
-        if (it != thread_ids.end()) {
-            int idx = it - thread_ids.begin();
-            measurement.at("tid") = idx;
-        } else {
-            thread_ids.emplace_back(measurement.at("tid"));
-            measurement.at("tid") = next_id++;
-        }
-    }
-    output_stream << session->json;
-    output_stream.flush();
-    output_stream.close();
-    delete session;
-    session = nullptr;
-}
-
-inline void Measurer::writeProfile(const TimerResult& result) {
-    if (session == nullptr) {
-        return;
-    }
-    std::string name = result.name;
-    std::replace(name.begin(), name.end(), '"', '\'');
-
-    nlohmann::json result_json = {
-        {"cat", "function"}, {"dur", result.end - result.start}, {"name", name},       {"ph", "X"},
-        {"pid", 0},          {"tid", result.thread_id},          {"ts", result.start},
-    };
-
-    std::lock_guard<std::mutex> lock(write_profile_mutex);
-    session->json.at("traceEvents").push_back(result_json);
-}
-
 inline Measurer& Measurer::get() {
     static Measurer instance;
     return instance;
 }
-
 
 inline Timer::Timer(const char* name) : name(name), stopped(false) {
     start_time = std::chrono::high_resolution_clock::now();
@@ -110,19 +68,6 @@ inline Timer::~Timer() {
     if (!stopped) {
         stop();
     }
-}
-
-inline void Timer::stop() {
-    std::chrono::high_resolution_clock::time_point end_time = std::chrono::high_resolution_clock::now();
-
-    long long start = std::chrono::time_point_cast<std::chrono::microseconds>(start_time).time_since_epoch().count();
-    long long end = std::chrono::time_point_cast<std::chrono::microseconds>(end_time).time_since_epoch().count();
-
-    size_t thread_id = std::hash<std::thread::id>{}(std::this_thread::get_id());
-
-    Measurer::get().writeProfile({name, start, end, thread_id});
-
-    stopped = true;
 }
 
 } // namespace dnd

--- a/tests/helper/argv.hpp
+++ b/tests/helper/argv.hpp
@@ -21,7 +21,7 @@ public:
             auto ptr = std::unique_ptr<char[]>(new char[len]);
 
             strcpy(ptr.get(), *iter);
-            m_args.push_back(std::move(ptr));
+            m_args.emplace_back(std::move(ptr));
             m_argv.get()[i] = m_args.back().get();
 
             iter++;

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -149,14 +149,14 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse characters of invalid fo
         // JSON is array
         nlohmann::json low_level_bob_array = nlohmann::json::array();
         for (const auto& [key, value] : low_level_bob.items()) {
-            low_level_bob_array.push_back(value);
+            low_level_bob_array.emplace_back(value);
         }
         parser.setJSON(low_level_bob_array);
         REQUIRE_THROWS(parser.parse());
 
         nlohmann::json high_level_bob_array = nlohmann::json::array();
         for (const auto& [key, value] : high_level_bob.items()) {
-            high_level_bob_array.push_back(value);
+            high_level_bob_array.emplace_back(value);
         }
         parser.setJSON(high_level_bob_array);
         REQUIRE_THROWS(parser.parse());

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -21,7 +21,7 @@ public:
         std::unordered_map<std::string, dnd::Character>& results,
         const std::unordered_map<std::string, const dnd::CharacterClass>& character_classes,
         const std::unordered_map<std::string, const dnd::CharacterSubclass>& character_subclasses,
-        const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
+        const std::unordered_map<std::string, const dnd::CharacterRace>& character_races,
         const std::unordered_map<std::string, const dnd::CharacterSubrace>& character_subraces,
         const std::unordered_map<std::string, const dnd::Spell>& spells
     )
@@ -38,7 +38,7 @@ class SetupCharacterParserTest {
 private:
     static const std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
     static const std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
-    static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>> character_races;
+    static const std::unordered_map<std::string, const dnd::CharacterRace> character_races;
     static const std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
     static const std::unordered_map<std::string, const dnd::Spell> spells;
 public:
@@ -53,9 +53,8 @@ inline const std::unordered_map<std::string, const dnd::CharacterSubclass>
     SetupCharacterParserTest::character_subclasses = {
         {"Path of the Berserker", dnd::CharacterSubclass("Path of the Berserker", "Barbarian")},
 };
-inline const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>
-    SetupCharacterParserTest::character_races = {
-        {"Dwarf", std::make_shared<dnd::CharacterRace>("Dwarf", true)},
+inline const std::unordered_map<std::string, const dnd::CharacterRace> SetupCharacterParserTest::character_races = {
+    {"Dwarf", dnd::CharacterRace("Dwarf", true)},
 };
 inline const std::unordered_map<std::string, const dnd::CharacterSubrace> SetupCharacterParserTest::character_subraces =
     {

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -20,7 +20,7 @@ public:
     TestCharacterFileParser(
         std::unordered_map<std::string, dnd::Character>& results,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>& character_classes,
-        const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>>& character_subclasses,
+        const std::unordered_map<std::string, const dnd::CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>>& character_subraces,
         const std::unordered_map<std::string, const dnd::Spell>& spells
@@ -37,7 +37,7 @@ public:
 class SetupCharacterParserTest {
 private:
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>> character_classes;
-    static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>> character_subclasses;
+    static const std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>> character_races;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>> character_subraces;
     static const std::unordered_map<std::string, const dnd::Spell> spells;
@@ -51,9 +51,9 @@ inline const std::unordered_map<std::string, std::shared_ptr<const dnd::Characte
         {"Barbarian",
          std::make_shared<dnd::CharacterClass>("Barbarian", "d12", std::vector<int>({4, 8, 12, 16, 19}), 3)},
 };
-inline const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>>
+inline const std::unordered_map<std::string, const dnd::CharacterSubclass>
     SetupCharacterParserTest::character_subclasses = {
-        {"Path of the Berserker", std::make_shared<dnd::CharacterSubclass>("Path of the Berserker", "Barbarian")},
+        {"Path of the Berserker", dnd::CharacterSubclass("Path of the Berserker", "Barbarian")},
 };
 inline const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>
     SetupCharacterParserTest::character_races = {

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -19,7 +19,7 @@ class TestCharacterFileParser : public dnd::CharacterFileParser {
 public:
     TestCharacterFileParser(
         std::unordered_map<std::string, dnd::Character>& results,
-        const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>& character_classes,
+        const std::unordered_map<std::string, const dnd::CharacterClass>& character_classes,
         const std::unordered_map<std::string, const dnd::CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
         const std::unordered_map<std::string, const dnd::CharacterSubrace>& character_subraces,
@@ -36,7 +36,7 @@ public:
 
 class SetupCharacterParserTest {
 private:
-    static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>> character_classes;
+    static const std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
     static const std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>> character_races;
     static const std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
@@ -46,10 +46,8 @@ public:
     TestCharacterFileParser createParser();
 };
 
-inline const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>
-    SetupCharacterParserTest::character_classes = {
-        {"Barbarian",
-         std::make_shared<dnd::CharacterClass>("Barbarian", "d12", std::vector<int>({4, 8, 12, 16, 19}), 3)},
+inline const std::unordered_map<std::string, const dnd::CharacterClass> SetupCharacterParserTest::character_classes = {
+    {"Barbarian", dnd::CharacterClass("Barbarian", "d12", std::vector<int>({4, 8, 12, 16, 19}), 3)},
 };
 inline const std::unordered_map<std::string, const dnd::CharacterSubclass>
     SetupCharacterParserTest::character_subclasses = {

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -22,7 +22,7 @@ public:
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>& character_classes,
         const std::unordered_map<std::string, const dnd::CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
-        const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>>& character_subraces,
+        const std::unordered_map<std::string, const dnd::CharacterSubrace>& character_subraces,
         const std::unordered_map<std::string, const dnd::Spell>& spells
     )
         : dnd::CharacterFileParser(
@@ -39,7 +39,7 @@ private:
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>> character_classes;
     static const std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>> character_races;
-    static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>> character_subraces;
+    static const std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
     static const std::unordered_map<std::string, const dnd::Spell> spells;
 public:
     std::unordered_map<std::string, dnd::Character> characters;
@@ -59,9 +59,9 @@ inline const std::unordered_map<std::string, std::shared_ptr<const dnd::Characte
     SetupCharacterParserTest::character_races = {
         {"Dwarf", std::make_shared<dnd::CharacterRace>("Dwarf", true)},
 };
-inline const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>>
-    SetupCharacterParserTest::character_subraces = {
-        {"Hill Dwarf", std::make_shared<dnd::CharacterSubrace>("Hill Dwarf", "Dwarf")},
+inline const std::unordered_map<std::string, const dnd::CharacterSubrace> SetupCharacterParserTest::character_subraces =
+    {
+        {"Hill Dwarf", dnd::CharacterSubrace("Hill Dwarf", "Dwarf")},
 };
 inline const std::unordered_map<std::string, const dnd::Spell> SetupCharacterParserTest::spells = {};
 

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -18,7 +18,7 @@
 class TestCharacterFileParser : public dnd::CharacterFileParser {
 public:
     TestCharacterFileParser(
-        std::unordered_map<std::string, std::shared_ptr<dnd::Character>>& results,
+        std::unordered_map<std::string, std::unique_ptr<dnd::Character>>& results,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>& character_classes,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
@@ -42,7 +42,7 @@ private:
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>> character_subraces;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>> spells;
 public:
-    std::unordered_map<std::string, std::shared_ptr<dnd::Character>> characters;
+    std::unordered_map<std::string, std::unique_ptr<dnd::Character>> characters;
     TestCharacterFileParser createParser();
 };
 
@@ -214,9 +214,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse logically wrong characte
     }
 }
 
-void testBasicValuesFromJSON(
-    const nlohmann::json& character_json, std::shared_ptr<const dnd::Character> character_ptr
-) {
+void testBasicValuesFromJSON(const nlohmann::json& character_json, const dnd::Character* const character_ptr) {
     REQUIRE(character_ptr->name == character_json.at("name").get<std::string>());
     REQUIRE(character_ptr->class_ptr->name == character_json.at("class"));
     if (character_json.contains("subclass")) {
@@ -262,7 +260,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         {"xp", 170000},
         {"hit_dice_rolls", {8, 11, 7, 6, 12, 4, 5, 3, 3, 7, 9, 7, 4, 2, 10}},
     };
-    std::shared_ptr<const dnd::Character> character_ptr;
+    const dnd::Character* character_ptr;
     SECTION("characters with level only") {
         valid_low_level_bob.erase("xp");
         parser.setJSON(valid_low_level_bob);
@@ -270,7 +268,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
         REQUIRE(character_ptr->getXP() == dnd::xp_for_level.at(valid_low_level_bob.at("level").get<int>()));
 
@@ -280,7 +278,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
         REQUIRE(character_ptr->getXP() == dnd::xp_for_level.at(valid_high_level_bob.at("level").get<int>()));
     }
@@ -291,7 +289,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
         REQUIRE(character_ptr->getLevel() == dnd::Character::levelForXP(valid_low_level_bob.at("xp").get<int>()));
 
@@ -301,7 +299,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
         REQUIRE(character_ptr->getLevel() == dnd::Character::levelForXP(valid_high_level_bob.at("xp").get<int>()));
     }
@@ -311,7 +309,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
 
         parser.setJSON(valid_high_level_bob);
@@ -319,7 +317,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name"));
+        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
     }
 }

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -18,12 +18,12 @@
 class TestCharacterFileParser : public dnd::CharacterFileParser {
 public:
     TestCharacterFileParser(
-        std::unordered_map<std::string, std::unique_ptr<dnd::Character>>& results,
+        std::unordered_map<std::string, dnd::Character>& results,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterClass>>& character_classes,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>>& character_subclasses,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>>& character_races,
         const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>>& character_subraces,
-        const std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>>& spells
+        const std::unordered_map<std::string, const dnd::Spell>& spells
     )
         : dnd::CharacterFileParser(
             results, character_classes, character_subclasses, character_races, character_subraces, spells
@@ -40,9 +40,9 @@ private:
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubclass>> character_subclasses;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterRace>> character_races;
     static const std::unordered_map<std::string, std::shared_ptr<const dnd::CharacterSubrace>> character_subraces;
-    static const std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>> spells;
+    static const std::unordered_map<std::string, const dnd::Spell> spells;
 public:
-    std::unordered_map<std::string, std::unique_ptr<dnd::Character>> characters;
+    std::unordered_map<std::string, dnd::Character> characters;
     TestCharacterFileParser createParser();
 };
 
@@ -63,7 +63,7 @@ inline const std::unordered_map<std::string, std::shared_ptr<const dnd::Characte
     SetupCharacterParserTest::character_subraces = {
         {"Hill Dwarf", std::make_shared<dnd::CharacterSubrace>("Hill Dwarf", "Dwarf")},
 };
-inline const std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>> SetupCharacterParserTest::spells = {};
+inline const std::unordered_map<std::string, const dnd::Spell> SetupCharacterParserTest::spells = {};
 
 inline TestCharacterFileParser SetupCharacterParserTest::createParser() {
     return TestCharacterFileParser(
@@ -268,7 +268,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_low_level_bob.at("name"));
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
         REQUIRE(character_ptr->getXP() == dnd::xp_for_level.at(valid_low_level_bob.at("level").get<int>()));
 
@@ -278,7 +278,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_high_level_bob.at("name"));
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
         REQUIRE(character_ptr->getXP() == dnd::xp_for_level.at(valid_high_level_bob.at("level").get<int>()));
     }
@@ -289,7 +289,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_low_level_bob.at("name"));
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
         REQUIRE(character_ptr->getLevel() == dnd::Character::levelForXP(valid_low_level_bob.at("xp").get<int>()));
 
@@ -299,7 +299,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_high_level_bob.at("name"));
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
         REQUIRE(character_ptr->getLevel() == dnd::Character::levelForXP(valid_high_level_bob.at("xp").get<int>()));
     }
@@ -309,7 +309,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 1);
-        character_ptr = setup.characters.at(valid_low_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_low_level_bob.at("name"));
         testBasicValuesFromJSON(valid_low_level_bob, character_ptr);
 
         parser.setJSON(valid_high_level_bob);
@@ -317,7 +317,7 @@ TEST_CASE("dnd::CharacterParser::createCharacter: parse minimum characters") {
         REQUIRE(parser.validate());
         REQUIRE_NOTHROW(parser.saveResult());
         REQUIRE(setup.characters.size() == 2);
-        character_ptr = setup.characters.at(valid_high_level_bob.at("name")).get();
+        character_ptr = &setup.characters.at(valid_high_level_bob.at("name"));
         testBasicValuesFromJSON(valid_high_level_bob, character_ptr);
     }
 }

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -36,31 +36,69 @@ public:
 
 class SetupCharacterParserTest {
 private:
-    static const std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
-    static const std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
-    static const std::unordered_map<std::string, const dnd::CharacterRace> character_races;
-    static const std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
-    static const std::unordered_map<std::string, const dnd::Spell> spells;
+    static bool values_set;
+    static std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
+    static std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
+    static std::unordered_map<std::string, const dnd::CharacterRace> character_races;
+    static std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
+    static std::unordered_map<std::string, const dnd::Spell> spells;
+    static void setClasses();
+    static void setSubclasses();
+    static void setRaces();
+    static void setSubraces();
+    static void setSpells();
 public:
     std::unordered_map<std::string, dnd::Character> characters;
+    SetupCharacterParserTest();
     TestCharacterFileParser createParser();
 };
 
-inline const std::unordered_map<std::string, const dnd::CharacterClass> SetupCharacterParserTest::character_classes = {
-    {"Barbarian", dnd::CharacterClass("Barbarian", "d12", std::vector<int>({4, 8, 12, 16, 19}), 3)},
-};
-inline const std::unordered_map<std::string, const dnd::CharacterSubclass>
-    SetupCharacterParserTest::character_subclasses = {
-        {"Path of the Berserker", dnd::CharacterSubclass("Path of the Berserker", "Barbarian")},
-};
-inline const std::unordered_map<std::string, const dnd::CharacterRace> SetupCharacterParserTest::character_races = {
-    {"Dwarf", dnd::CharacterRace("Dwarf", true)},
-};
-inline const std::unordered_map<std::string, const dnd::CharacterSubrace> SetupCharacterParserTest::character_subraces =
-    {
-        {"Hill Dwarf", dnd::CharacterSubrace("Hill Dwarf", "Dwarf")},
-};
-inline const std::unordered_map<std::string, const dnd::Spell> SetupCharacterParserTest::spells = {};
+bool SetupCharacterParserTest::values_set = false;
+std::unordered_map<std::string, const dnd::CharacterClass> SetupCharacterParserTest::character_classes = {};
+std::unordered_map<std::string, const dnd::CharacterSubclass> SetupCharacterParserTest::character_subclasses = {};
+std::unordered_map<std::string, const dnd::CharacterRace> SetupCharacterParserTest::character_races = {};
+std::unordered_map<std::string, const dnd::CharacterSubrace> SetupCharacterParserTest::character_subraces = {};
+std::unordered_map<std::string, const dnd::Spell> SetupCharacterParserTest::spells = {};
+
+inline void SetupCharacterParserTest::setClasses() {
+    character_classes.emplace(
+        std::piecewise_construct, std::forward_as_tuple("Barbarian"),
+        std::forward_as_tuple("Barbarian", "d12", std::vector<int>({4, 8, 12, 16, 19}), 3)
+    );
+}
+
+inline void SetupCharacterParserTest::setSubclasses() {
+    character_subclasses.emplace(
+        std::piecewise_construct, std::forward_as_tuple("Path of the Berserker"),
+        std::forward_as_tuple("Path of the Berserker", "Barbarian")
+    );
+}
+
+inline void SetupCharacterParserTest::setRaces() {
+    character_races.emplace(
+        std::piecewise_construct, std::forward_as_tuple("Dwarf"), std::forward_as_tuple("Dwarf", true)
+    );
+}
+
+inline void SetupCharacterParserTest::setSubraces() {
+    character_subraces.emplace(
+        std::piecewise_construct, std::forward_as_tuple("Hill Dwarf"), std::forward_as_tuple("Hill Dwarf", "Dwarf")
+    );
+}
+
+inline void SetupCharacterParserTest::setSpells() {}
+
+
+inline SetupCharacterParserTest::SetupCharacterParserTest() {
+    if (!values_set) {
+        setClasses();
+        setSubclasses();
+        setRaces();
+        setSubraces();
+        setSpells();
+        values_set = true;
+    }
+}
 
 inline TestCharacterFileParser SetupCharacterParserTest::createParser() {
     return TestCharacterFileParser(

--- a/tests/parsing/models/feature_holder_file_parser_test.cpp
+++ b/tests/parsing/models/feature_holder_file_parser_test.cpp
@@ -19,10 +19,10 @@ public:
     void parseAndAddActivationForTesting(const std::string& activation_str, dnd::Feature& feature) const {
         dnd::FeatureHolderFileParser::parseAndAddActivation(activation_str, feature);
     }
-    std::shared_ptr<dnd::Feature> createFeatureForTesting(
+    std::unique_ptr<dnd::Feature> createFeatureForTesting(
         const std::string& feature_name, const nlohmann::json& feature_json
     ) const {
-        return dnd::FeatureHolderFileParser::createFeature(feature_name, feature_json);
+        return std::make_unique<dnd::Feature>(dnd::FeatureHolderFileParser::createFeature(feature_name, feature_json));
     }
     void parse() override {}
     bool validate() const override { return true; }
@@ -991,7 +991,7 @@ TEST_CASE("dnd::FeatureHolderFileParser::createFeature: parse valid features") {
         const nlohmann::json feature_json = {
             {"description", description},
         };
-        std::shared_ptr<dnd::Feature> feature;
+        std::unique_ptr<dnd::Feature> feature;
         REQUIRE_NOTHROW(feature = std::move(parser.createFeatureForTesting(name, feature_json)));
         REQUIRE(feature->name == name);
         REQUIRE(feature->description == description);
@@ -1008,7 +1008,7 @@ TEST_CASE("dnd::FeatureHolderFileParser::createFeature: parse valid features") {
             {"description", description},
             {"effects", effects_json},
         };
-        std::shared_ptr<dnd::Feature> feature;
+        std::unique_ptr<dnd::Feature> feature;
         REQUIRE_NOTHROW(feature = std::move(parser.createFeatureForTesting(name, feature_json)));
         REQUIRE(feature->name == name);
         REQUIRE(feature->description == description);
@@ -1045,7 +1045,7 @@ TEST_CASE("dnd::FeatureHolderFileParser::createFeature: parse valid features") {
             {"description", description},
             {"effects", effects_json},
         };
-        std::shared_ptr<dnd::Feature> feature;
+        std::unique_ptr<dnd::Feature> feature;
         REQUIRE_NOTHROW(feature = std::move(parser.createFeatureForTesting(name, feature_json)));
         REQUIRE(feature->name == name);
         REQUIRE(feature->description == description);

--- a/tests/parsing/models/spells_file_parser_test.cpp
+++ b/tests/parsing/models/spells_file_parser_test.cpp
@@ -12,8 +12,7 @@
 // class that allows us to test the dnd::SpellsFileParser class
 class TestSpellsFileParser : public dnd::SpellsFileParser {
 public:
-    TestSpellsFileParser(std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>>& results)
-        : dnd::SpellsFileParser(results) {}
+    TestSpellsFileParser(std::unordered_map<std::string, const dnd::Spell>& results) : dnd::SpellsFileParser(results) {}
     dnd::SpellType createSpellTypeForTesting(const std::string& spell_type_str) const {
         return dnd::SpellsFileParser::createSpellType(spell_type_str);
     }
@@ -27,7 +26,7 @@ public:
 
 class SetupSpellsParserTest {
 public:
-    std::unordered_map<std::string, std::shared_ptr<const dnd::Spell>> spells;
+    std::unordered_map<std::string, const dnd::Spell> spells;
     TestSpellsFileParser createParser();
 };
 


### PR DESCRIPTION
Since the parsing doesn't use the polymorphism of the feature holders any more (which is good), there is no reason anymore to not store the characters, classes, races and spells directly in the maps instead of storing maps of pointers.

Additionally to this change, I change a few non-owning smart pointers into raw pointers.