### PR TITLE
Remove redundant parsing errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ endif()
 
 if(MSVC)
     add_compile_options(/W4 /WX)
+    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 else()
     add_compile_options(
         -pedantic -Wall -Wextra -Wpedantic -Werror -Wdisabled-optimization -Wcast-qual -Wold-style-cast
@@ -75,6 +76,7 @@ else()
     endif()
 endif()
 
+# Main Application
 add_executable(${DND_APP_TARGET} src/main.cpp)
 set_target_properties(${DND_APP_TARGET} PROPERTIES EXPORT_COMPILE_COMMANDS ON)
 
@@ -87,6 +89,7 @@ target_include_directories(${DND_APP_TARGET}
 )
 target_link_libraries(${DND_APP_TARGET} PUBLIC nlohmann_json::nlohmann_json cxxopts::cxxopts)
 
+# Unit Tests
 add_executable(${DND_TEST_TARGET})
 set_target_properties(${DND_TEST_TARGET} PROPERTIES EXPORT_COMPILE_COMMANDS ON)
 
@@ -107,13 +110,8 @@ include(Catch.cmake)
 catch_discover_tests(${DND_TEST_TARGET}) # include catch2 tests
 
 add_subdirectory(src)
-
 add_subdirectory(tests)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
-
-if(MSVC)
-    add_definitions(-D_CRT_SECURE_NO_WARNINGS)
-endif()

--- a/src/parsing/controllers/effect_holder_groups_file_parser.cpp
+++ b/src/parsing/controllers/effect_holder_groups_file_parser.cpp
@@ -44,7 +44,7 @@ dnd::Choosable dnd::EffectHolderGroupsFileParser::createChoosable(
     choosable.main_part = effect_holder_parser.createEffectHolder(choosable_json);
     if (choosable_json.contains("multi")) {
         if (!choosable_json.is_array()) {
-            throw attribute_format_error(filepath, "multi", "array");
+            throw attribute_format_error(type, filepath, "multi", "array");
         }
         for (const auto& part_json : choosable_json) {
             choosable.parts.emplace_back(effect_holder_parser.createEffectHolder(part_json));

--- a/src/parsing/models/spells_file_parser.cpp
+++ b/src/parsing/models/spells_file_parser.cpp
@@ -42,7 +42,7 @@ void dnd::SpellsFileParser::createSpell(std::string_view spell_name, const nlohm
 void dnd::SpellsFileParser::parse() {
     DND_MEASURE_FUNCTION();
     if (!json_to_parse.is_object()) {
-        throw json_format_error(ParsingType::SPELL, filepath, "map/object");
+        throw json_format_error(type, filepath, "map/object");
     }
     spells_in_file = json_to_parse.size();
     spell_parsing_info.reserve(spells_in_file);
@@ -50,7 +50,7 @@ void dnd::SpellsFileParser::parse() {
     std::vector<std::future<void>> futures;
     for (const auto& [spell_name, spell_json] : json_to_parse.items()) {
         if (spell_name.empty()) {
-            throw invalid_attribute(ParsingType::SPELL, filepath, "spell name", "cannot be \"\".");
+            throw invalid_attribute(type, filepath, "spell name", "cannot be \"\".");
         }
         futures.emplace_back(
             std::async(std::launch::async, &SpellsFileParser::createSpell, this, spell_name, spell_json)
@@ -69,7 +69,7 @@ dnd::SpellType dnd::SpellsFileParser::createSpellType(const std::string& spell_t
     DND_MEASURE_FUNCTION();
     if (!std::regex_match(spell_type_str, spell_type_regex)) {
         // TODO: think about how to reintroduce spell name into error message
-        throw attribute_type_error(filepath, "invalid spell type format: \"" + spell_type_str + "\"");
+        throw attribute_type_error(type, filepath, "invalid spell type format: \"" + spell_type_str + "\"");
     }
     SpellType spell_type;
     size_t ritual_idx = spell_type_str.find(" (ritual)");
@@ -98,7 +98,7 @@ dnd::SpellComponents dnd::SpellsFileParser::createSpellComponents(const std::str
     DND_MEASURE_FUNCTION();
     if (!std::regex_match(spell_components_str, spell_components_regex)) {
         // TODO: think about how to reintroduce spell name into error message
-        throw attribute_type_error(filepath, "invalid spell components format: \"" + spell_components_str + "\"");
+        throw attribute_type_error(type, filepath, "invalid spell components format: \"" + spell_components_str + "\"");
     }
     size_t parentheses_idx = spell_components_str.find(" (");
     std::string first_part = (parentheses_idx == std::string::npos) ? spell_components_str

--- a/src/parsing/models/spells_file_parser.hpp
+++ b/src/parsing/models/spells_file_parser.hpp
@@ -17,6 +17,7 @@
 #include "controllers/groups.hpp"
 #include "models/spell.hpp"
 #include "parsing/content_file_parser.hpp"
+#include "parsing/parsing_types.hpp"
 
 namespace dnd {
 
@@ -39,6 +40,7 @@ protected:
     SpellType createSpellType(const std::string& spell_type_str) const;
     SpellComponents createSpellComponents(const std::string& spell_components_str) const;
 private:
+    static const ParsingType type;
     std::unordered_map<std::string, const Spell>& spells;
     Groups& groups;
     size_t spells_in_file;
@@ -47,6 +49,8 @@ private:
     std::mutex spell_parsing_mutex;
     virtual void configureSubparsers() override;
 };
+
+inline const ParsingType SpellsFileParser::type = ParsingType::SPELL;
 
 inline SpellsFileParser::SpellsFileParser(std::unordered_map<std::string, const Spell>& spells, Groups& groups) noexcept
     : ContentFileParser(), spells(spells), groups(groups) {}

--- a/src/parsing/parsing_exceptions.hpp
+++ b/src/parsing/parsing_exceptions.hpp
@@ -18,7 +18,6 @@ class parsing_error : public std::invalid_argument {
 public:
     parsing_error(const std::filesystem::path& path, const std::string& error_msg);
     parsing_error(ParsingType parsing_type, const std::filesystem::path& path, const std::string& error_msg);
-    void setParsingType(ParsingType parsing_type);
     void relativiseFileName(const std::filesystem::path& root_path);
     const char* what() const noexcept override;
 private:
@@ -32,16 +31,12 @@ private:
 // thrown when a json file is not formatted the way it's supposed to
 class json_format_error : public parsing_error {
 public:
-    json_format_error(const std::filesystem::path& path, const std::string& desired_format);
     json_format_error(ParsingType parsing_type, const std::filesystem::path& path, const std::string& desired_format);
 };
 
 // thrown when an attribute is not formatted the way it's supposed to
 class attribute_format_error : public parsing_error {
 public:
-    attribute_format_error(
-        const std::filesystem::path& path, const std::string& attribute, const std::string& desired_format
-    );
     attribute_format_error(
         ParsingType parsing_type, const std::filesystem::path& path, const std::string& attribute,
         const std::string& desired_format
@@ -51,7 +46,6 @@ public:
 // thrown when a required attribute is missing i.e. the key is missing in the JSON file
 class attribute_missing : public parsing_error {
 public:
-    attribute_missing(const std::filesystem::path& path, const std::string& missing_attribute_msg);
     attribute_missing(
         ParsingType parsing_type, const std::filesystem::path& path, const std::string& missing_attribute_msg
     );
@@ -60,7 +54,6 @@ public:
 // throw when an attribute is of a wrong type
 class attribute_type_error : public parsing_error {
 public:
-    attribute_type_error(const std::filesystem::path& path, const std::string& type_error_msg);
     attribute_type_error(
         ParsingType parsing_type, const std::filesystem::path& path, const std::string& type_error_msg
     );
@@ -69,7 +62,6 @@ public:
 // thrown when an attribute has a logically wrong or forbidden value
 class invalid_attribute : public parsing_error {
 public:
-    invalid_attribute(const std::filesystem::path& path, const std::string& attribute, const std::string& error_msg);
     invalid_attribute(
         ParsingType parsing_type, const std::filesystem::path& path, const std::string& attribute,
         const std::string& error_msg
@@ -99,11 +91,6 @@ inline parsing_error::parsing_error(
 
 inline void parsing_error::updateWhat() { w = msg_start + " \"" + path.string() + "\" " + error_msg; }
 
-inline void parsing_error::setParsingType(ParsingType parsing_type) {
-    msg_start = parsing_type_names.at(parsing_type) + " in file";
-    updateWhat();
-}
-
 
 inline void parsing_error::relativiseFileName(const std::filesystem::path& root_path) {
     path = path.lexically_relative(root_path);
@@ -112,20 +99,11 @@ inline void parsing_error::relativiseFileName(const std::filesystem::path& root_
 
 inline const char* parsing_error::what() const noexcept { return w.c_str(); }
 
-inline json_format_error::json_format_error(const std::filesystem::path& path, const std::string& desired_format)
-    : parsing_error(path, "has wrong format: should be " + desired_format) {}
-
 
 inline json_format_error::json_format_error(
     dnd::ParsingType parsing_type, const std::filesystem::path& path, const std::string& desired_format
 )
     : parsing_error(parsing_type, path, "has wrong format: should be " + desired_format) {}
-
-
-inline attribute_format_error::attribute_format_error(
-    const std::filesystem::path& path, const std::string& attribute, const std::string& desired_format
-)
-    : parsing_error(path, "has attribute of wrong format: \"" + attribute + "\" should be " + desired_format) {}
 
 
 inline attribute_format_error::attribute_format_error(
@@ -137,30 +115,16 @@ inline attribute_format_error::attribute_format_error(
     ) {}
 
 
-inline attribute_missing::attribute_missing(const std::filesystem::path& path, const std::string& missing_attribute_msg)
-    : parsing_error(path, "is missing an attribute: " + missing_attribute_msg) {}
-
-
 inline attribute_missing::attribute_missing(
     dnd::ParsingType parsing_type, const std::filesystem::path& path, const std::string& missing_attribute_msg
 )
     : parsing_error(parsing_type, path, "is missing an attribute: " + missing_attribute_msg) {}
 
 
-inline attribute_type_error::attribute_type_error(const std::filesystem::path& path, const std::string& type_error_msg)
-    : parsing_error(path, "has attribute of wrong type: " + type_error_msg) {}
-
-
 inline attribute_type_error::attribute_type_error(
     ParsingType parsing_type, const std::filesystem::path& path, const std::string& type_error_msg
 )
     : parsing_error(parsing_type, path, "has attribute of wrong type: " + type_error_msg) {}
-
-
-inline invalid_attribute::invalid_attribute(
-    const std::filesystem::path& path, const std::string& attribute, const std::string& error_msg
-)
-    : parsing_error(path, "has invalid attribute \"" + attribute + "\": " + error_msg) {}
 
 
 inline invalid_attribute::invalid_attribute(


### PR DESCRIPTION
After the parser refactor #32, there is no need anymore for any parsing exception constructors that don't take a parsing type. Because all file parsers but also subparsers now have a parsing type.