### PR TITLE
Refactor parser configuration

### DIFF
--- a/src/models/effect_holder/effect_holder.hpp
+++ b/src/models/effect_holder/effect_holder.hpp
@@ -25,6 +25,7 @@ namespace dnd {
 class EffectHolder {
 public:
     EffectHolder() noexcept = default;
+    virtual ~EffectHolder() noexcept = default;
     EffectHolder(EffectHolder&& other) noexcept = default;
     EffectHolder& operator=(EffectHolder&& other) noexcept = default;
     /**

--- a/src/models/feature_holder.hpp
+++ b/src/models/feature_holder.hpp
@@ -22,6 +22,7 @@ public:
      * @param features a collection of features this holder provides to a character of its type
      */
     FeatureHolder(const std::string& name, std::vector<Feature>&& features) noexcept;
+    virtual ~FeatureHolder() noexcept = default;
 
     // the name of the feature holder
     const std::string name;

--- a/src/parsing/content_file_parser.cpp
+++ b/src/parsing/content_file_parser.cpp
@@ -8,13 +8,9 @@
 
 #include <nlohmann/json.hpp>
 
-bool dnd::ContentFileParser::openJSON(const std::filesystem::directory_entry& file) {
+bool dnd::ContentFileParser::openJSON() {
     DND_MEASURE_FUNCTION();
-    if (!file.is_regular_file()) {
-        std::cerr << "Warning: " << file.path() << " is not a regular file.\n";
-        return false;
-    }
-    filepath = file.path();
+
     if (filepath.extension().string() != ".json") {
         std::cerr << "Warning: " << filepath << " is not a \".json\" file.\n";
         return false;

--- a/src/parsing/content_file_parser.cpp
+++ b/src/parsing/content_file_parser.cpp
@@ -23,6 +23,5 @@ bool dnd::ContentFileParser::openJSON() {
         std::cerr << "Warning: Error occured while parsing " << filepath << ":\n" << e.what() << '\n';
         return false;
     }
-    configureSubparsers();
     return true;
 }

--- a/src/parsing/content_file_parser.hpp
+++ b/src/parsing/content_file_parser.hpp
@@ -54,12 +54,6 @@ public:
     // the file which is being parsed
     const std::filesystem::path filepath;
 protected:
-    /**
-     * @brief This function is automatically called after successfully opening the JSON file to set the properties of
-     * subparsers if necessary.
-     */
-    virtual void configureSubparsers() = 0;
-
     // the json content that is being parsed
     nlohmann::json json_to_parse;
 };

--- a/src/parsing/content_file_parser.hpp
+++ b/src/parsing/content_file_parser.hpp
@@ -17,13 +17,18 @@ namespace dnd {
  */
 class ContentFileParser {
 public:
+    /**
+     * @brief Constructs a ContentFileParser for a given file
+     * @param filepath the file to parse
+     */
+    ContentFileParser(const std::filesystem::path& filepath) noexcept;
+    ContentFileParser(ContentFileParser&& other) noexcept = default;
     virtual ~ContentFileParser() noexcept = default;
     /**
-     * @brief Opens a json file to be parsed and deserialises the JSON.
-     * @param filepath the file to open
+     * @brief Opens the json file to be parsed and deserialises the JSON.
      * @return "true" if opening and deserialising was successful, "false" otherwise
      */
-    virtual bool openJSON(const std::filesystem::directory_entry& filepath);
+    virtual bool openJSON();
     /**
      * @brief Parses JSON content file.
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -40,17 +45,26 @@ public:
      * @brief Saves the parsed content.
      */
     virtual void saveResult() = 0;
+    /**
+     * @brief Returns the type of content that this parser parses
+     * @return the type of content that this parser parses
+     */
+    virtual ParsingType getType() const = 0;
+
+    // the file which is being parsed
+    const std::filesystem::path filepath;
 protected:
-    // the json content that is being parsed
-    nlohmann::json json_to_parse;
-    // the file which is being parsed (useful for error messages)
-    std::filesystem::path filepath;
     /**
      * @brief This function is automatically called after successfully opening the JSON file to set the properties of
      * subparsers if necessary.
      */
     virtual void configureSubparsers() = 0;
+
+    // the json content that is being parsed
+    nlohmann::json json_to_parse;
 };
+
+inline ContentFileParser::ContentFileParser(const std::filesystem::path& filepath) noexcept : filepath(filepath) {}
 
 } // namespace dnd
 

--- a/src/parsing/controllers/content_parser.cpp
+++ b/src/parsing/controllers/content_parser.cpp
@@ -89,12 +89,12 @@ dnd::Content dnd::ContentParser::parse(
     return std::move(parsed_content);
 }
 
-std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createSingleFileParserForType(
-    const dnd::ParsingType parsing_type
+std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createSingleFileParser(
+    const std::filesystem::path filepath, const dnd::ParsingType parsing_type
 ) {
     switch (parsing_type) {
         case ParsingType::GROUP:
-            return std::make_unique<StringGroupsFileParser>(parsed_content.groups);
+            return std::make_unique<StringGroupsFileParser>(filepath, parsed_content.groups);
         default:
             throw std::logic_error(
                 "No single-file parser for content type \"" + std::string(parsingTypeName(parsing_type)) + "\" exists."
@@ -102,35 +102,37 @@ std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createSingleFilePars
     }
 }
 
-std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createMultiFileParserForType(
-    const dnd::ParsingType parsing_type
+std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createMultiFileParser(
+    const std::filesystem::path filepath, const dnd::ParsingType parsing_type
 ) {
     switch (parsing_type) {
         case ParsingType::CHARACTER:
             return std::make_unique<CharacterFileParser>(
-                parsed_content.characters, parsed_content.groups, parsed_content.character_classes,
+                filepath, parsed_content.characters, parsed_content.groups, parsed_content.character_classes,
                 parsed_content.character_subclasses, parsed_content.character_races, parsed_content.character_subraces,
                 parsed_content.spells
             );
         case ParsingType::RACE:
-            return std::make_unique<CharacterRaceFileParser>(parsed_content.character_races, parsed_content.groups);
+            return std::make_unique<CharacterRaceFileParser>(
+                filepath, parsed_content.character_races, parsed_content.groups
+            );
         case ParsingType::SUBRACE:
             return std::make_unique<CharacterSubraceFileParser>(
-                parsed_content.character_subraces, parsed_content.groups, parsed_content.character_races
+                filepath, parsed_content.character_subraces, parsed_content.groups, parsed_content.character_races
             );
         case ParsingType::CLASS:
             return std::make_unique<CharacterClassFileParser>(
-                parsed_content.character_classes, parsed_content.groups, parsed_content.spells
+                filepath, parsed_content.character_classes, parsed_content.groups, parsed_content.spells
             );
         case ParsingType::SUBCLASS:
             return std::make_unique<CharacterSubclassFileParser>(
-                parsed_content.character_subclasses, parsed_content.groups, parsed_content.character_classes,
+                filepath, parsed_content.character_subclasses, parsed_content.groups, parsed_content.character_classes,
                 parsed_content.spells
             );
         case ParsingType::SPELL:
-            return std::make_unique<SpellsFileParser>(parsed_content.spells, parsed_content.groups);
+            return std::make_unique<SpellsFileParser>(filepath, parsed_content.spells, parsed_content.groups);
         case ParsingType::GROUP:
-            return std::make_unique<EffectHolderGroupsFileParser>(parsed_content.groups);
+            return std::make_unique<EffectHolderGroupsFileParser>(filepath, parsed_content.groups);
         default:
             throw std::logic_error(
                 "No multi-file parser for content type \"" + std::string(parsingTypeName(parsing_type)) + "\" exists."
@@ -138,21 +140,12 @@ std::unique_ptr<dnd::ContentFileParser> dnd::ContentParser::createMultiFileParse
     }
 }
 
-void dnd::ContentParser::parseFileOfType(
-    const std::filesystem::directory_entry& file, const ParsingType parsing_type, bool multi_file
-) {
-    DND_MEASURE_SCOPE(("dnd::ContentParser::parseFileOfType ( " + std::string(parsingTypeName(parsing_type)) + ", "
-                       + (multi_file ? "multi-file" : "single-file") + " )")
+void dnd::ContentParser::parseFile(std::unique_ptr<ContentFileParser> parser) {
+    DND_MEASURE_SCOPE(("dnd::ContentParser::parseFile ( " + std::string(parsingTypeName(parser->getType())) + ", "
+                       + parser->filepath.filename().string() + " )")
                           .c_str());
 
-    std::unique_ptr<ContentFileParser> parser;
-    if (multi_file) {
-        parser = createMultiFileParserForType(parsing_type);
-    } else {
-        parser = createSingleFileParserForType(parsing_type);
-    }
-
-    if (!parser->openJSON(file)) {
+    if (!parser->openJSON()) {
         return;
     }
 
@@ -160,14 +153,14 @@ void dnd::ContentParser::parseFileOfType(
         parser->parse();
     } catch (const nlohmann::json::out_of_range& e) {
         const std::string stripped_what = stripJsonExceptionWhat(e.what());
-        throw attribute_missing(parsing_type, file.path(), stripped_what);
+        throw attribute_missing(parser->getType(), parser->filepath, stripped_what);
     } catch (const nlohmann::json::type_error& e) {
         const std::string stripped_what = stripJsonExceptionWhat(e.what());
-        throw attribute_type_error(parsing_type, file.path(), stripped_what);
+        throw attribute_type_error(parser->getType(), parser->filepath, stripped_what);
     }
 
     if (parser->validate()) {
-        std::lock_guard<std::mutex> lock(parsing_mutexes[parsing_type]);
+        std::lock_guard<std::mutex> lock(parsing_mutexes[parser->getType()]);
         parser->saveResult();
     }
 }
@@ -188,7 +181,7 @@ void dnd::ContentParser::parseAllOfSingleFileType(const ParsingType parsing_type
     DND_MEASURE_SCOPE(
         ("dnd::ContentParser::parseAllOfSingleFileType ( " + std::string(parsingTypeName(parsing_type)) + " )").c_str()
     );
-    std::vector<std::filesystem::directory_entry> files_to_parse;
+    std::vector<std::unique_ptr<ContentFileParser>> to_parse;
     std::vector<std::future<void>> futures;
     for (const auto& dir : dirs_to_parse) {
         auto type_file_it = std::find_if(
@@ -212,13 +205,11 @@ void dnd::ContentParser::parseAllOfSingleFileType(const ParsingType parsing_type
                       << " so that it cannot be confused with a file containing " << type_file_name << '\n';
             continue;
         }
-        files_to_parse.emplace_back(type_file);
+        to_parse.emplace_back(std::move(createSingleFileParser(type_file.path(), parsing_type)));
     }
 
-    for (const auto& file : files_to_parse) {
-        futures.emplace_back(
-            std::async(std::launch::async, &ContentParser::parseFileOfType, this, file, parsing_type, false)
-        );
+    for (auto& parser : to_parse) {
+        futures.emplace_back(std::async(std::launch::async, &ContentParser::parseFile, this, std::move(parser)));
     }
     for (auto& future : futures) {
         try {
@@ -233,7 +224,7 @@ void dnd::ContentParser::parseAllOfMultiFileType(const ParsingType parsing_type)
     DND_MEASURE_SCOPE(
         ("dnd::ContentParser::parseAllOfMultiFileType ( " + std::string(parsingTypeName(parsing_type)) + " )").c_str()
     );
-    std::vector<std::filesystem::directory_entry> files_to_parse;
+    std::vector<std::unique_ptr<ContentFileParser>> to_parse;
     std::vector<std::future<void>> futures;
     for (const auto& dir : dirs_to_parse) {
         auto type_dir_it = std::find_if(
@@ -257,14 +248,16 @@ void dnd::ContentParser::parseAllOfMultiFileType(const ParsingType parsing_type)
             continue;
         }
         for (const auto& file : std::filesystem::directory_iterator(type_subdir)) {
-            files_to_parse.emplace_back(file);
+            if (!file.is_regular_file()) {
+                std::cerr << "Warning: " << file.path() << " is not a regular file.\n";
+                continue;
+            }
+            to_parse.emplace_back(std::move(createMultiFileParser(file.path(), parsing_type)));
         }
     }
 
-    for (const auto& file : files_to_parse) {
-        futures.emplace_back(
-            std::async(std::launch::async, &ContentParser::parseFileOfType, this, file, parsing_type, true)
-        );
+    for (auto& parser : to_parse) {
+        futures.emplace_back(std::async(std::launch::async, &ContentParser::parseFile, this, std::move(parser)));
     }
     for (auto& future : futures) {
         try {

--- a/src/parsing/controllers/content_parser.cpp
+++ b/src/parsing/controllers/content_parser.cpp
@@ -205,7 +205,7 @@ void dnd::ContentParser::parseAllOfSingleFileType(const ParsingType parsing_type
                       << " so that it cannot be confused with a file containing " << type_file_name << '\n';
             continue;
         }
-        to_parse.emplace_back(std::move(createSingleFileParser(type_file.path(), parsing_type)));
+        to_parse.emplace_back(createSingleFileParser(type_file.path(), parsing_type));
     }
 
     for (auto& parser : to_parse) {
@@ -252,7 +252,7 @@ void dnd::ContentParser::parseAllOfMultiFileType(const ParsingType parsing_type)
                 std::cerr << "Warning: " << file.path() << " is not a regular file.\n";
                 continue;
             }
-            to_parse.emplace_back(std::move(createMultiFileParser(file.path(), parsing_type)));
+            to_parse.emplace_back(createMultiFileParser(file.path(), parsing_type));
         }
     }
 

--- a/src/parsing/controllers/content_parser.hpp
+++ b/src/parsing/controllers/content_parser.hpp
@@ -55,27 +55,31 @@ private:
      */
     void parseAllOfMultiFileType(const ParsingType parsing_type);
     /**
-     * @brief Handles parsing of one file given the way of how it should be parsed
-     * @param file the file path
-     * @param parsing_type the type of content in the file that should be parsed
-     * @param multi_file "true" if the content type should be parsed in a multi-file way, "false" otherwise
-     * @throws parsing_error if any error occured while trying to parse the file
+     * @brief Handles parsing of one file by one parser
+     * @param parser the parser
+     * @throws parsing_error if any error occured while trying to parse the file with the parser
      */
-    void parseFileOfType(const std::filesystem::directory_entry& file, const ParsingType parsing_type, bool multi_file);
+    void parseFile(std::unique_ptr<ContentFileParser> parser);
     /**
      * @brief Creates a Parser for single-file parsing of a certain type
+     * @param filepath the file to parse
      * @param parsing_type the content type to be parser
      * @return the single-file parser for that content type
      * @throws std::logic_error if no single-file parser exists for that content type
      */
-    std::unique_ptr<ContentFileParser> createSingleFileParserForType(const ParsingType parsing_type);
+    std::unique_ptr<ContentFileParser> createSingleFileParser(
+        const std::filesystem::path filepath, const ParsingType parsing_type
+    );
     /**
      * @brief Creates a Parser for multi-file parsing of a certain type
+     * @param filepath the file to parse
      * @param parsing_type the content type to be parser
      * @return the multi-file parser for that content type
      * @throws std::logic_error if no single-file parser exists for that content type
      */
-    std::unique_ptr<ContentFileParser> createMultiFileParserForType(const ParsingType parsing_type);
+    std::unique_ptr<ContentFileParser> createMultiFileParser(
+        const std::filesystem::path filepath, const ParsingType parsing_type
+    );
 
     // the names of the files containing single-file content types
     static const std::array<std::pair<dnd::ParsingType, const char*>, 1> file_names;

--- a/src/parsing/controllers/effect_holder_groups_file_parser.hpp
+++ b/src/parsing/controllers/effect_holder_groups_file_parser.hpp
@@ -3,6 +3,7 @@
 
 #include "dnd_config.hpp"
 
+#include <filesystem>
 #include <string>
 #include <unordered_map>
 
@@ -22,9 +23,10 @@ class EffectHolderGroupsFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs an EffectHolderGroupsFileParser
+     * @param filepath the file to parse
      * @param groups the already-parsed groups
      */
-    EffectHolderGroupsFileParser(Groups& groups) noexcept;
+    EffectHolderGroupsFileParser(const std::filesystem::path& filepath, Groups& groups) noexcept;
     /**
      * @brief Parses JSON file containing a choosable group
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -41,6 +43,11 @@ public:
      * @brief Saves the parsed group to the groups.
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - choosable groups
+     * @return the type of content that this parser parses - choosable groups
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 private:
     /**
      * @brief Parse and create a choosable
@@ -69,8 +76,10 @@ private:
     EffectHolderParser effect_holder_parser;
 };
 
-inline EffectHolderGroupsFileParser::EffectHolderGroupsFileParser(Groups& groups) noexcept
-    : ContentFileParser(), groups(groups), effect_holder_parser(groups) {}
+inline EffectHolderGroupsFileParser::EffectHolderGroupsFileParser(
+    const std::filesystem::path& filepath, Groups& groups
+) noexcept
+    : ContentFileParser(filepath), groups(groups), effect_holder_parser(groups) {}
 
 inline void EffectHolderGroupsFileParser::configureSubparsers() { effect_holder_parser.configure(type, filepath); }
 

--- a/src/parsing/controllers/effect_holder_groups_file_parser.hpp
+++ b/src/parsing/controllers/effect_holder_groups_file_parser.hpp
@@ -59,10 +59,6 @@ private:
      * @throws nlohmann::json::type_error if any of the parsed attributes have the wrong type
      */
     Choosable createChoosable(const std::string& name, const nlohmann::json& choosable_json) const;
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
 
     // the type of content that this parser parses - choosable groups
     static constexpr ParsingType type = ParsingType::GROUP;
@@ -79,9 +75,7 @@ private:
 inline EffectHolderGroupsFileParser::EffectHolderGroupsFileParser(
     const std::filesystem::path& filepath, Groups& groups
 ) noexcept
-    : ContentFileParser(filepath), groups(groups), effect_holder_parser(groups) {}
-
-inline void EffectHolderGroupsFileParser::configureSubparsers() { effect_holder_parser.configure(type, filepath); }
+    : ContentFileParser(filepath), groups(groups), effect_holder_parser(type, filepath, groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/controllers/string_groups_file_parser.hpp
+++ b/src/parsing/controllers/string_groups_file_parser.hpp
@@ -56,10 +56,6 @@ private:
      * @throws attribute_format_error if the map's format is invalid
      */
     std::unordered_set<std::string> parseMap(const nlohmann::json& json_map);
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
 
     // the type of content that this parser parses - string groups
     static constexpr ParsingType type = ParsingType::GROUP;
@@ -72,9 +68,7 @@ private:
 };
 
 inline StringGroupsFileParser::StringGroupsFileParser(const std::filesystem::path& filepath, Groups& groups) noexcept
-    : ContentFileParser(filepath), groups(groups), effect_holder_parser(groups) {}
-
-inline void StringGroupsFileParser::configureSubparsers() { effect_holder_parser.configure(type, filepath); }
+    : ContentFileParser(filepath), groups(groups), effect_holder_parser(type, filepath, groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/controllers/string_groups_file_parser.hpp
+++ b/src/parsing/controllers/string_groups_file_parser.hpp
@@ -23,9 +23,10 @@ class StringGroupsFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs an StringGroupsFileParser
+     * @param filepath the file to parse
      * @param groups the already-parsed groups
      */
-    StringGroupsFileParser(Groups& groups) noexcept;
+    StringGroupsFileParser(const std::filesystem::path& filepath, Groups& groups) noexcept;
     /**
      * @brief Parses JSON file containing a string group
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -42,6 +43,11 @@ public:
      * @brief Saves the parsed group to the groups.
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - string groups
+     * @return the type of content that this parser parses - string groups
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 private:
     /**
      * @brief Parses one level of the input-map and saves the results in parsed_data
@@ -65,8 +71,8 @@ private:
     EffectHolderParser effect_holder_parser;
 };
 
-inline StringGroupsFileParser::StringGroupsFileParser(Groups& groups) noexcept
-    : ContentFileParser(), groups(groups), effect_holder_parser(groups) {}
+inline StringGroupsFileParser::StringGroupsFileParser(const std::filesystem::path& filepath, Groups& groups) noexcept
+    : ContentFileParser(filepath), groups(groups), effect_holder_parser(groups) {}
 
 inline void StringGroupsFileParser::configureSubparsers() { effect_holder_parser.configure(type, filepath); }
 

--- a/src/parsing/models/character_class_file_parser.hpp
+++ b/src/parsing/models/character_class_file_parser.hpp
@@ -65,11 +65,6 @@ protected:
      */
     void determineSubclassLevel(const std::vector<Feature>& features);
 private:
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-
     // the type of content that this parser parses - classes
     static constexpr ParsingType type = ParsingType::CLASS;
     // the name of the parsed class
@@ -92,12 +87,8 @@ inline CharacterClassFileParser::CharacterClassFileParser(
     const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterClass>& classes,
     const Groups& groups, const std::unordered_map<std::string, const Spell>& spells
 ) noexcept
-    : ContentFileParser(filepath), classes(classes), features_parser(groups), spellcasting_parser(spells) {}
-
-inline void CharacterClassFileParser::configureSubparsers() {
-    features_parser.configure(type, filepath);
-    spellcasting_parser.configure(type, filepath);
-}
+    : ContentFileParser(filepath), classes(classes), features_parser(type, filepath, groups),
+      spellcasting_parser(type, filepath, spells) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_class_file_parser.hpp
+++ b/src/parsing/models/character_class_file_parser.hpp
@@ -27,13 +27,14 @@ class CharacterClassFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a CharacterClassFileParser
+     * @param filepath the file to parse
      * @param classes the already-parsed classes
      * @param groups the already-parsed groups
      * @param spells the already-parsed spells
      */
     CharacterClassFileParser(
-        std::unordered_map<std::string, const CharacterClass>& classes, const Groups& groups,
-        const std::unordered_map<std::string, const Spell>& spells
+        const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterClass>& classes,
+        const Groups& groups, const std::unordered_map<std::string, const Spell>& spells
     ) noexcept;
     /**
      * @brief Parses JSON file containing a class
@@ -51,6 +52,11 @@ public:
      * @brief Saves the parsed class
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - classes
+     * @return the type of content that this parser parses - classes
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 protected:
     /**
      * @brief Determine the subclass level for the parsed class
@@ -83,10 +89,10 @@ private:
 };
 
 inline CharacterClassFileParser::CharacterClassFileParser(
-    std::unordered_map<std::string, const CharacterClass>& classes, const Groups& groups,
-    const std::unordered_map<std::string, const Spell>& spells
+    const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterClass>& classes,
+    const Groups& groups, const std::unordered_map<std::string, const Spell>& spells
 ) noexcept
-    : ContentFileParser(), classes(classes), features_parser(groups), spellcasting_parser(spells) {}
+    : ContentFileParser(filepath), classes(classes), features_parser(groups), spellcasting_parser(spells) {}
 
 inline void CharacterClassFileParser::configureSubparsers() {
     features_parser.configure(type, filepath);

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -32,6 +32,7 @@ class CharacterFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a CharacterFileParser
+     * @param filepath the file to parse
      * @param characters the already-parsed characters
      * @param groups the already-parsed groups
      * @param character_classes the already-parsed classes
@@ -41,8 +42,8 @@ public:
      * @param spells the already-parsed spells
      */
     CharacterFileParser(
-        std::unordered_map<std::string, Character>& characters, const Groups& groups,
-        const std::unordered_map<std::string, const CharacterClass>& character_classes,
+        const std::filesystem::path& filepath, std::unordered_map<std::string, Character>& characters,
+        const Groups& groups, const std::unordered_map<std::string, const CharacterClass>& character_classes,
         const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, const CharacterRace>& character_races,
         const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
@@ -64,6 +65,11 @@ public:
      * @brief Saves the parsed character
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - characters
+     * @return the type of content that this parser parses - characters
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 protected:
     /**
      * @brief Parse the character decision for a choice required by a particular feature-like object
@@ -136,14 +142,14 @@ private:
 };
 
 inline CharacterFileParser::CharacterFileParser(
-    std::unordered_map<std::string, Character>& characters, const Groups& groups,
+    const std::filesystem::path& filepath, std::unordered_map<std::string, Character>& characters, const Groups& groups,
     const std::unordered_map<std::string, const CharacterClass>& character_classes,
     const std::unordered_map<std::string, const CharacterSubclass>& character_subclasses,
     const std::unordered_map<std::string, const CharacterRace>& character_races,
     const std::unordered_map<std::string, const CharacterSubrace>& character_subraces,
     const std::unordered_map<std::string, const Spell>& spells
 ) noexcept
-    : ContentFileParser(), class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr),
+    : ContentFileParser(filepath), class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr),
       characters(characters), character_classes(character_classes), character_subclasses(character_subclasses),
       character_races(character_races), character_subraces(character_subraces), spells(spells),
       effect_holder_parser(groups), features_parser(groups) {}

--- a/src/parsing/models/character_file_parser.hpp
+++ b/src/parsing/models/character_file_parser.hpp
@@ -82,10 +82,6 @@ protected:
     void parseCharacterDecisions(const std::string& feature_name, const nlohmann::json& feature_decisions_json);
 private:
     /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-    /**
      * @brief Parses the class, race, subclass, and subrace of the character
      * @throws parsing_error if the chosen class, race, subclass, or subrace is invalid
      * @throws nlohmann::json::out_of_range if any required attribute does not exist
@@ -152,9 +148,7 @@ inline CharacterFileParser::CharacterFileParser(
     : ContentFileParser(filepath), class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr),
       characters(characters), character_classes(character_classes), character_subclasses(character_subclasses),
       character_races(character_races), character_subraces(character_subraces), spells(spells),
-      effect_holder_parser(groups), features_parser(groups) {}
-
-inline void CharacterFileParser::configureSubparsers() { effect_holder_parser.configure(type, filepath); }
+      effect_holder_parser(type, filepath, groups), features_parser(type, filepath, groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_race_file_parser.hpp
+++ b/src/parsing/models/character_race_file_parser.hpp
@@ -22,10 +22,14 @@ class CharacterRaceFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a CharacterRaceFileParser
+     * @param filepath the file to parse
      * @param races the already-parsed races
      * @param groups the already-parsed groups
      */
-    CharacterRaceFileParser(std::unordered_map<std::string, const CharacterRace>& races, const Groups& groups) noexcept;
+    CharacterRaceFileParser(
+        const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterRace>& races,
+        const Groups& groups
+    ) noexcept;
     /**
      * @brief Parses JSON file containing a race
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -42,6 +46,11 @@ public:
      * @brief Saves the parsed race
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - races
+     * @return the type of content that this parser parses - races
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 private:
     /**
      * @brief Configures the subparsers used
@@ -61,9 +70,10 @@ private:
 };
 
 inline CharacterRaceFileParser::CharacterRaceFileParser(
-    std::unordered_map<std::string, const CharacterRace>& races, const Groups& groups
+    const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterRace>& races,
+    const Groups& groups
 ) noexcept
-    : ContentFileParser(), races(races), features_parser(groups) {}
+    : ContentFileParser(filepath), races(races), features_parser(groups) {}
 
 inline void CharacterRaceFileParser::configureSubparsers() { features_parser.configure(type, filepath); }
 

--- a/src/parsing/models/character_race_file_parser.hpp
+++ b/src/parsing/models/character_race_file_parser.hpp
@@ -52,11 +52,6 @@ public:
      */
     virtual constexpr ParsingType getType() const override { return type; };
 private:
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-
     // the type of content that this parser parses - races
     static constexpr ParsingType type = ParsingType::RACE;
     // the name of the parsed race
@@ -73,9 +68,7 @@ inline CharacterRaceFileParser::CharacterRaceFileParser(
     const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterRace>& races,
     const Groups& groups
 ) noexcept
-    : ContentFileParser(filepath), races(races), features_parser(groups) {}
-
-inline void CharacterRaceFileParser::configureSubparsers() { features_parser.configure(type, filepath); }
+    : ContentFileParser(filepath), races(races), features_parser(type, filepath, groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -24,14 +24,15 @@ class CharacterSubclassFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a CharacterSubclassFileParser
+     * @param filepath the file to parse
      * @param subclasses the already-parsed subclasses
      * @param groups the already-parsed groups
      * @param classes the already-parsed classes
      * @param spells the already-parsed spells
      */
     CharacterSubclassFileParser(
-        std::unordered_map<std::string, const CharacterSubclass>& subclasses, const Groups& groups,
-        const std::unordered_map<std::string, const CharacterClass>& classes,
+        const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterSubclass>& subclasses,
+        const Groups& groups, const std::unordered_map<std::string, const CharacterClass>& classes,
         const std::unordered_map<std::string, const Spell>& spells
     ) noexcept;
     /**
@@ -51,6 +52,11 @@ public:
      * @brief Saves the parsed subclass
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - subclasses
+     * @return the type of content that this parser parses - subclasses
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 private:
     /**
      * @brief Configures the subparsers used
@@ -74,11 +80,11 @@ private:
 };
 
 inline CharacterSubclassFileParser::CharacterSubclassFileParser(
-    std::unordered_map<std::string, const CharacterSubclass>& subclasses, const Groups& groups,
-    const std::unordered_map<std::string, const CharacterClass>& classes,
+    const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterSubclass>& subclasses,
+    const Groups& groups, const std::unordered_map<std::string, const CharacterClass>& classes,
     const std::unordered_map<std::string, const Spell>& spells
 ) noexcept
-    : ContentFileParser(), subclasses(subclasses), classes(classes), features_parser(groups),
+    : ContentFileParser(filepath), subclasses(subclasses), classes(classes), features_parser(groups),
       spellcasting_parser(spells) {}
 
 inline void CharacterSubclassFileParser::configureSubparsers() {

--- a/src/parsing/models/character_subclass_file_parser.hpp
+++ b/src/parsing/models/character_subclass_file_parser.hpp
@@ -58,11 +58,6 @@ public:
      */
     virtual constexpr ParsingType getType() const override { return type; };
 private:
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-
     // the type of content that this parser parses - subclasses
     static constexpr ParsingType type = ParsingType::SUBCLASS;
     // the name of the parsed subclass
@@ -84,13 +79,8 @@ inline CharacterSubclassFileParser::CharacterSubclassFileParser(
     const Groups& groups, const std::unordered_map<std::string, const CharacterClass>& classes,
     const std::unordered_map<std::string, const Spell>& spells
 ) noexcept
-    : ContentFileParser(filepath), subclasses(subclasses), classes(classes), features_parser(groups),
-      spellcasting_parser(spells) {}
-
-inline void CharacterSubclassFileParser::configureSubparsers() {
-    features_parser.configure(type, filepath);
-    spellcasting_parser.configure(type, filepath);
-}
+    : ContentFileParser(filepath), subclasses(subclasses), classes(classes), features_parser(type, filepath, groups),
+      spellcasting_parser(type, filepath, spells) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -56,11 +56,6 @@ public:
      */
     virtual constexpr ParsingType getType() const override { return type; };
 private:
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-
     // the type of content that this parser parses - subraces
     static constexpr ParsingType type = ParsingType::SUBRACE;
     // the name of the parsed subrace
@@ -79,9 +74,7 @@ inline CharacterSubraceFileParser::CharacterSubraceFileParser(
     const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterSubrace>& subraces,
     const Groups& groups, const std::unordered_map<std::string, const CharacterRace>& races
 ) noexcept
-    : ContentFileParser(filepath), subraces(subraces), races(races), features_parser(groups) {}
-
-inline void CharacterSubraceFileParser::configureSubparsers() { features_parser.configure(type, filepath); }
+    : ContentFileParser(filepath), subraces(subraces), races(races), features_parser(type, filepath, groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/character_subrace_file_parser.hpp
+++ b/src/parsing/models/character_subrace_file_parser.hpp
@@ -24,13 +24,14 @@ class CharacterSubraceFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a CharacterSubraceFileParser
+     * @param filepath the file to parse
      * @param subraces the already-parsed subraces
      * @param groups the already-parsed groups
      * @param races the already-parsed races
      */
     CharacterSubraceFileParser(
-        std::unordered_map<std::string, const CharacterSubrace>& subraces, const Groups& groups,
-        const std::unordered_map<std::string, const CharacterRace>& races
+        const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterSubrace>& subraces,
+        const Groups& groups, const std::unordered_map<std::string, const CharacterRace>& races
     ) noexcept;
     /**
      * @brief Parses JSON file containing a subrace
@@ -49,6 +50,11 @@ public:
      * @brief Saves the parsed subrace
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - subraces
+     * @return the type of content that this parser parses - subraces
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 private:
     /**
      * @brief Configures the subparsers used
@@ -70,10 +76,10 @@ private:
 };
 
 inline CharacterSubraceFileParser::CharacterSubraceFileParser(
-    std::unordered_map<std::string, const CharacterSubrace>& subraces, const Groups& groups,
-    const std::unordered_map<std::string, const CharacterRace>& races
+    const std::filesystem::path& filepath, std::unordered_map<std::string, const CharacterSubrace>& subraces,
+    const Groups& groups, const std::unordered_map<std::string, const CharacterRace>& races
 ) noexcept
-    : ContentFileParser(), subraces(subraces), races(races), features_parser(groups) {}
+    : ContentFileParser(filepath), subraces(subraces), races(races), features_parser(groups) {}
 
 inline void CharacterSubraceFileParser::configureSubparsers() { features_parser.configure(type, filepath); }
 

--- a/src/parsing/models/effect_holder/effect_holder_parser.cpp
+++ b/src/parsing/models/effect_holder/effect_holder_parser.cpp
@@ -89,8 +89,6 @@ static void parseProficienciesOptionals(
 void dnd::EffectHolderParser::parseEffectHolder(
     const nlohmann::json& effect_holder_json, dnd::EffectHolder* const effect_holder
 ) const {
-    requiresConfiguration();
-
     parseActionsOptionals(effect_holder_json, effect_holder);
     parseExtraSpellsOptionals(effect_holder_json, effect_holder);
     parseRIVsOptionals(effect_holder_json, effect_holder);
@@ -139,8 +137,6 @@ dnd::EffectHolderWithChoices dnd::EffectHolderParser::createEffectHolderWithChoi
 ) const {
     DND_MEASURE_FUNCTION();
 
-    requiresConfiguration();
-
     // TODO: change effect holder constructor?
     EffectHolderWithChoices effect_holder;
 
@@ -162,8 +158,6 @@ dnd::EffectHolderWithChoices dnd::EffectHolderParser::createEffectHolderWithChoi
 void dnd::EffectHolderParser::parseAndAddChoice(
     const std::string& choice_key, const nlohmann::json& choice_json, EffectHolderWithChoices& effect_holder
 ) const {
-    requiresConfiguration();
-
     int amount = choice_json.at("amount").get<int>();
 
     if (choice_json.contains("choices")) {
@@ -225,8 +219,6 @@ void dnd::EffectHolderParser::parseAndAddChoice(
 }
 
 std::unique_ptr<dnd::Effect> dnd::EffectHolderParser::createEffect(const std::string& effect_str) const {
-    requiresConfiguration();
-
     if (!std::regex_match(effect_str, effect_regex)) {
         throw attribute_type_error(type, filepath, "invalid effect format: \"" + effect_str + "\"");
     }
@@ -300,8 +292,6 @@ void dnd::EffectHolderParser::parseAndAddEffect(const std::string& effect_str, E
 void dnd::EffectHolderParser::parseAndAddActivation(
     const std::string& activation_str, EffectHolder* const effect_holder
 ) const {
-    requiresConfiguration();
-
     if (!std::regex_match(activation_str, activation_regex)) {
         throw attribute_type_error(type, filepath, "invalid activation format: \"" + activation_str + "\"");
     }

--- a/src/parsing/models/effect_holder/effect_holder_parser.hpp
+++ b/src/parsing/models/effect_holder/effect_holder_parser.hpp
@@ -26,7 +26,7 @@ public:
      * @brief Constructs an EffectHolderParser
      * @param groups the already-parsed groups
      */
-    EffectHolderParser(const Groups& groups) noexcept;
+    EffectHolderParser(ParsingType type, const std::filesystem::path& filepath, const Groups& groups) noexcept;
     /**
      * @brief Parse and create an effect holder (without any choices to be made)
      * @param effect_holder_json the JSON containing the effect holder
@@ -96,8 +96,11 @@ private:
     const Groups& groups;
 };
 
-inline EffectHolderParser::EffectHolderParser(const Groups& groups) noexcept
-    : activation_regex(activation_regex_cstr), effect_regex(effect_regex_cstr), groups(groups) {}
+inline EffectHolderParser::EffectHolderParser(
+    ParsingType type, const std::filesystem::path& filepath, const Groups& groups
+) noexcept
+    : Subparser(type, filepath), activation_regex(activation_regex_cstr), effect_regex(effect_regex_cstr),
+      groups(groups) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/effect_holder/features_parser.cpp
+++ b/src/parsing/models/effect_holder/features_parser.cpp
@@ -17,8 +17,6 @@
 void dnd::FeaturesParser::parseFeatures(const nlohmann::json& features_json) {
     DND_MEASURE_FUNCTION();
 
-    requiresConfiguration();
-
     if (!features_json.is_object()) {
         throw attribute_format_error(type, filepath, "features", "map/object");
     }
@@ -32,8 +30,6 @@ void dnd::FeaturesParser::parseFeatures(const nlohmann::json& features_json) {
 
 dnd::Feature dnd::FeaturesParser::createFeature(const std::string& feature_name, const nlohmann::json& feature_json)
     const {
-    requiresConfiguration();
-
     const std::string description = feature_json.at("description").get<std::string>();
 
     // TODO: change feature constructor?

--- a/src/parsing/models/effect_holder/features_parser.hpp
+++ b/src/parsing/models/effect_holder/features_parser.hpp
@@ -28,7 +28,7 @@ public:
      * @brief Constructs an FeaturesParser
      * @param groups the already-parsed groups
      */
-    FeaturesParser(const Groups& groups) noexcept;
+    FeaturesParser(ParsingType type, const std::filesystem::path& filepath, const Groups& groups) noexcept;
     /**
      * @brief Parse features from a JSON
      * @param features_json the JSON that need s ot be parsed
@@ -45,12 +45,6 @@ public:
      * @return the parsed features as r-value-reference
      */
     std::vector<Feature>&& retrieveFeatures();
-    /**
-     * @brief Configure the parsing type and the file path for the parser and all its subparsers
-     * @param conf_type the type of content of the file that is being parsed
-     * @param conf_filepath the file that is being parsed
-     */
-    virtual void configure(ParsingType conf_type, const std::filesystem::path& conf_filepath) noexcept override;
 protected:
     /**
      * @brief Parse and create a feature
@@ -69,16 +63,14 @@ private:
     EffectHolderParser effect_holder_parser;
 };
 
-inline FeaturesParser::FeaturesParser(const Groups& groups) noexcept : Subparser(), effect_holder_parser(groups) {}
+inline FeaturesParser::FeaturesParser(
+    ParsingType type, const std::filesystem::path& filepath, const Groups& groups
+) noexcept
+    : Subparser(type, filepath), effect_holder_parser(type, filepath, groups) {}
 
 inline const std::vector<Feature>& FeaturesParser::getFeatures() const { return features; }
 
 inline std::vector<Feature>&& FeaturesParser::retrieveFeatures() { return std::move(features); }
-
-inline void FeaturesParser::configure(ParsingType conf_type, const std::filesystem::path& conf_filepath) noexcept {
-    Subparser::configure(conf_type, conf_filepath);
-    effect_holder_parser.configure(conf_type, conf_filepath);
-}
 
 } // namespace dnd
 

--- a/src/parsing/models/spellcasting/spellcasting_parser.cpp
+++ b/src/parsing/models/spellcasting/spellcasting_parser.cpp
@@ -22,8 +22,6 @@
 void dnd::SpellcastingParser::parseSize20Array(
     const nlohmann::json& json_to_parse, const char* attribute_name, std::array<int, 20>& output
 ) {
-    requiresConfiguration();
-
     if (!json_to_parse.contains(attribute_name)) {
         output = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         return;
@@ -37,8 +35,6 @@ void dnd::SpellcastingParser::parseSize20Array(
 
 void dnd::SpellcastingParser::parseSpellcasting(const nlohmann::json& spellcasting_json) {
     DND_MEASURE_FUNCTION();
-
-    requiresConfiguration();
 
     ability = spellcasting_json.at("ability").get<std::string>();
     if (!isAbility(ability)) {

--- a/src/parsing/models/spellcasting/spellcasting_parser.hpp
+++ b/src/parsing/models/spellcasting/spellcasting_parser.hpp
@@ -35,7 +35,10 @@ public:
      * @brief Constructs a SpellcastingParser
      * @param spells the already-parsed spells
      */
-    SpellcastingParser(const std::unordered_map<std::string, const Spell>& spells) noexcept;
+    SpellcastingParser(
+        ParsingType type, const std::filesystem::path& filepath,
+        const std::unordered_map<std::string, const Spell>& spells
+    ) noexcept;
     /**
      * @brief Parses the spellcasting feature from a given JSON
      * @param spellcasting_json the JSON that needs to be parsed
@@ -81,8 +84,10 @@ private:
     std::array<std::array<int, 20>, 9> spell_slots;
 };
 
-inline SpellcastingParser::SpellcastingParser(const std::unordered_map<std::string, const Spell>& spells) noexcept
-    : Subparser(), spells(spells) {}
+inline SpellcastingParser::SpellcastingParser(
+    ParsingType type, const std::filesystem::path& filepath, const std::unordered_map<std::string, const Spell>& spells
+) noexcept
+    : Subparser(type, filepath), spells(spells) {}
 
 } // namespace dnd
 

--- a/src/parsing/models/spells_file_parser.hpp
+++ b/src/parsing/models/spells_file_parser.hpp
@@ -50,10 +50,13 @@ class SpellsFileParser : public ContentFileParser {
 public:
     /**
      * @brief Constructs a SpellsFileParser
+     * @param filepath the file to parse
      * @param spells the already-parsed spells
      * @param groups the already-parsed groups
      */
-    SpellsFileParser(std::unordered_map<std::string, const Spell>& spells, Groups& groups) noexcept;
+    SpellsFileParser(
+        const std::filesystem::path& filepath, std::unordered_map<std::string, const Spell>& spells, Groups& groups
+    ) noexcept;
     /**
      * @brief Parses JSON file containing a collection of spells
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -70,6 +73,11 @@ public:
      * @brief Saves the parsed spells
      */
     virtual void saveResult() override;
+    /**
+     * @brief Returns the type of content that this parser parses - spells
+     * @return the type of content that this parser parses - spells
+     */
+    virtual constexpr ParsingType getType() const override { return type; };
 protected:
     /**
      * @brief Parses a spell and saves its information
@@ -124,9 +132,11 @@ private:
     std::mutex spell_parsing_mutex;
 };
 
-inline SpellsFileParser::SpellsFileParser(std::unordered_map<std::string, const Spell>& spells, Groups& groups) noexcept
-    : ContentFileParser(), spell_components_regex(spell_type_regex_cstr), spell_type_regex(spell_components_regex_cstr),
-      spells(spells), groups(groups) {}
+inline SpellsFileParser::SpellsFileParser(
+    const std::filesystem::path& filepath, std::unordered_map<std::string, const Spell>& spells, Groups& groups
+) noexcept
+    : ContentFileParser(filepath), spell_components_regex(spell_type_regex_cstr),
+      spell_type_regex(spell_components_regex_cstr), spells(spells), groups(groups) {}
 
 inline void SpellsFileParser::configureSubparsers() {} // SpellsFileParser has no subparsers
 

--- a/src/parsing/models/spells_file_parser.hpp
+++ b/src/parsing/models/spells_file_parser.hpp
@@ -103,11 +103,6 @@ protected:
      */
     SpellComponents createSpellComponents(const std::string& spell_components_str) const;
 private:
-    /**
-     * @brief Configures the subparsers used
-     */
-    virtual void configureSubparsers() override;
-
     // the type of content that this parser parses - spells
     static constexpr ParsingType type = ParsingType::SPELL;
     // the c-style string to create the regular expression to check the validity of spell components from
@@ -137,8 +132,6 @@ inline SpellsFileParser::SpellsFileParser(
 ) noexcept
     : ContentFileParser(filepath), spell_components_regex(spell_type_regex_cstr),
       spell_type_regex(spell_components_regex_cstr), spells(spells), groups(groups) {}
-
-inline void SpellsFileParser::configureSubparsers() {} // SpellsFileParser has no subparsers
 
 } // namespace dnd
 

--- a/src/parsing/subparser.hpp
+++ b/src/parsing/subparser.hpp
@@ -4,7 +4,6 @@
 #include "dnd_config.hpp"
 
 #include <filesystem>
-#include <stdexcept>
 
 #include "parsing/parsing_types.hpp"
 
@@ -16,43 +15,22 @@ namespace dnd {
  */
 class Subparser {
 public:
-    Subparser() noexcept;
     /**
-     * @brief Configure the parsing type and the file path for the subparser that will be used when throwing exceptions
-     * for example.
-     * @param conf_type the type of content of the file that is being parsed
-     * @param conf_filepath the file that is being parsed
+     * @brief Constructs a subparser with the parsing type and filepath
+     * @param type the type of content of the file that is being parsed
+     * @param filepath the file that is being parsed
      */
-    virtual void configure(ParsingType conf_type, const std::filesystem::path& conf_filepath) noexcept;
-protected:
+    Subparser(ParsingType type, const std::filesystem::path& filepath) noexcept;
+    virtual ~Subparser() noexcept = default;
+
     // the type of content of the file that is being parsed
-    ParsingType type;
+    const ParsingType type;
     // the file that is being parsed
-    std::filesystem::path filepath;
-    /**
-     * @brief Asserts whether the subparser was configured.
-     * @throws std::logic_error if subparser is unconfigured
-     */
-    virtual void requiresConfiguration() const;
-private:
-    // "true" if the type and filepath for the subparser were configured already, "false" otherwise
-    bool configured;
+    const std::filesystem::path filepath;
 };
 
-inline Subparser::Subparser() noexcept
-    : type(ParsingType::CHARACTER /* just setting some inital value */), filepath(), configured(false) {}
-
-inline void Subparser::configure(ParsingType conf_type, const std::filesystem::path& conf_filepath) noexcept {
-    type = conf_type;
-    filepath = conf_filepath;
-    configured = true;
-}
-
-inline void Subparser::requiresConfiguration() const {
-    if (!configured) {
-        throw std::logic_error("Subparser was not configured. Call configure(type, path) first.");
-    }
-}
+inline Subparser::Subparser(ParsingType type, const std::filesystem::path& filepath) noexcept
+    : type(type), filepath(filepath) {}
 
 } // namespace dnd
 

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -25,20 +25,18 @@
 class TestCharacterFileParser : public dnd::CharacterFileParser {
 public:
     TestCharacterFileParser(
-        std::unordered_map<std::string, dnd::Character>& characters, const dnd::Groups& groups,
-        const std::unordered_map<std::string, const dnd::CharacterClass>& character_classes,
+        const std::filesystem::path& filepath, std::unordered_map<std::string, dnd::Character>& characters,
+        const dnd::Groups& groups, const std::unordered_map<std::string, const dnd::CharacterClass>& character_classes,
         const std::unordered_map<std::string, const dnd::CharacterSubclass>& character_subclasses,
         const std::unordered_map<std::string, const dnd::CharacterRace>& character_races,
         const std::unordered_map<std::string, const dnd::CharacterSubrace>& character_subraces,
         const std::unordered_map<std::string, const dnd::Spell>& spells
     )
         : dnd::CharacterFileParser(
-            characters, groups, character_classes, character_subclasses, character_races, character_subraces, spells
+            filepath, characters, groups, character_classes, character_subclasses, character_races, character_subraces,
+            spells
         ) {}
-    void setJSON(const nlohmann::json& character_json) {
-        filepath = std::filesystem::path("test_file_name.json");
-        json_to_parse = character_json;
-    }
+    void setJSON(const nlohmann::json& character_json) { json_to_parse = character_json; }
 };
 
 class SetupCharacterParserTest {
@@ -47,27 +45,19 @@ public:
     SetupCharacterParserTest();
     TestCharacterFileParser createParser();
 private:
-    static bool values_set;
-    static dnd::Groups groups;
-    static std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
-    static std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
-    static std::unordered_map<std::string, const dnd::CharacterRace> character_races;
-    static std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
-    static std::unordered_map<std::string, const dnd::Spell> spells;
-    static void setClasses();
-    static void setSubclasses();
-    static void setRaces();
-    static void setSubraces();
-    static void setSpells();
+    dnd::Groups groups;
+    const std::filesystem::path filepath;
+    std::unordered_map<std::string, const dnd::CharacterClass> character_classes;
+    std::unordered_map<std::string, const dnd::CharacterSubclass> character_subclasses;
+    std::unordered_map<std::string, const dnd::CharacterRace> character_races;
+    std::unordered_map<std::string, const dnd::CharacterSubrace> character_subraces;
+    std::unordered_map<std::string, const dnd::Spell> spells;
+    void setClasses();
+    void setSubclasses();
+    void setRaces();
+    void setSubraces();
+    void setSpells();
 };
-
-bool SetupCharacterParserTest::values_set = false;
-dnd::Groups SetupCharacterParserTest::groups;
-std::unordered_map<std::string, const dnd::CharacterClass> SetupCharacterParserTest::character_classes = {};
-std::unordered_map<std::string, const dnd::CharacterSubclass> SetupCharacterParserTest::character_subclasses = {};
-std::unordered_map<std::string, const dnd::CharacterRace> SetupCharacterParserTest::character_races = {};
-std::unordered_map<std::string, const dnd::CharacterSubrace> SetupCharacterParserTest::character_subraces = {};
-std::unordered_map<std::string, const dnd::Spell> SetupCharacterParserTest::spells = {};
 
 inline void SetupCharacterParserTest::setClasses() {
     character_classes.emplace(
@@ -102,20 +92,18 @@ inline void SetupCharacterParserTest::setSubraces() {
 inline void SetupCharacterParserTest::setSpells() {}
 
 
-inline SetupCharacterParserTest::SetupCharacterParserTest() {
-    if (!values_set) {
-        setClasses();
-        setSubclasses();
-        setRaces();
-        setSubraces();
-        setSpells();
-        values_set = true;
-    }
+inline SetupCharacterParserTest::SetupCharacterParserTest() : groups(), filepath("testing") {
+    setClasses();
+    setSubclasses();
+    setRaces();
+    setSubraces();
+    setSpells();
 }
 
 inline TestCharacterFileParser SetupCharacterParserTest::createParser() {
     return TestCharacterFileParser(
-        characters, groups, character_classes, character_subclasses, character_races, character_subraces, spells
+        filepath, characters, groups, character_classes, character_subclasses, character_races, character_subraces,
+        spells
     );
 }
 

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -22,6 +22,9 @@
 #include "models/effect_holder/feature.hpp"
 #include "models/spell.hpp"
 
+/**
+ * @brief A class that allows us to test the dnd::CharacterFileParser class
+ */
 class TestCharacterFileParser : public dnd::CharacterFileParser {
 public:
     TestCharacterFileParser(

--- a/tests/parsing/models/effect_holder/effect_holder_parser_test.cpp
+++ b/tests/parsing/models/effect_holder/effect_holder_parser_test.cpp
@@ -13,7 +13,9 @@
 #include "models/effect_holder/effect_holder.hpp"
 #include "parsing/parsing_types.hpp"
 
-// class that allows us to test the abstract dnd::EffectHolderParser class
+/**
+ * @brief A class that allows us to test the dnd::EffectHolderParser class
+ */
 class TestEffectHolderParser : public dnd::EffectHolderParser {
 public:
     TestEffectHolderParser() noexcept

--- a/tests/parsing/models/effect_holder/effect_holder_parser_test.cpp
+++ b/tests/parsing/models/effect_holder/effect_holder_parser_test.cpp
@@ -16,7 +16,8 @@
 // class that allows us to test the abstract dnd::EffectHolderParser class
 class TestEffectHolderParser : public dnd::EffectHolderParser {
 public:
-    TestEffectHolderParser() noexcept : dnd::EffectHolderParser(dnd::Groups()) {}
+    TestEffectHolderParser() noexcept
+        : dnd::EffectHolderParser(dnd::ParsingType::CHARACTER, "testing", dnd::Groups()) {}
     void parseAndAddEffectForTesting(const std::string& effect_str, dnd::EffectHolder& effect_holder) const {
         dnd::EffectHolderParser::parseAndAddEffect(effect_str, &effect_holder);
     }
@@ -26,7 +27,6 @@ public:
     dnd::EffectHolder createEffectHolderForTesting(const nlohmann::json& effect_holder_json) const {
         return createEffectHolder(effect_holder_json);
     }
-    virtual void requiresConfiguration() const override {} // for testing, no configuration is required
 };
 
 TEST_CASE("dnd::EffectHolderParser::parseAndAddEffect: parse invalid effects") {

--- a/tests/parsing/models/effect_holder/features_parser_test.cpp
+++ b/tests/parsing/models/effect_holder/features_parser_test.cpp
@@ -10,7 +10,9 @@
 #include "models/effect_holder/feature.hpp"
 #include "parsing/parsing_types.hpp"
 
-// class that allows us to test the abstract dnd::FeaturesParser class
+/**
+ * @brief A class that allows us to test the dnd::FeaturesParser class
+ */
 class TestFeaturesParser : public dnd::FeaturesParser {
 public:
     TestFeaturesParser() noexcept : dnd::FeaturesParser(dnd::ParsingType::CHARACTER, "testing", dnd::Groups()) {}

--- a/tests/parsing/models/effect_holder/features_parser_test.cpp
+++ b/tests/parsing/models/effect_holder/features_parser_test.cpp
@@ -8,15 +8,15 @@
 
 #include "controllers/groups.hpp"
 #include "models/effect_holder/feature.hpp"
+#include "parsing/parsing_types.hpp"
 
 // class that allows us to test the abstract dnd::FeaturesParser class
 class TestFeaturesParser : public dnd::FeaturesParser {
 public:
-    TestFeaturesParser() noexcept : dnd::FeaturesParser(dnd::Groups()) {}
+    TestFeaturesParser() noexcept : dnd::FeaturesParser(dnd::ParsingType::CHARACTER, "testing", dnd::Groups()) {}
     dnd::Feature createFeatureForTesting(const std::string& feature_name, const nlohmann::json& feature_json) const {
         return createFeature(feature_name, feature_json);
     }
-    virtual void requiresConfiguration() const override {} // for testing, no configuration is required
 };
 
 TEST_CASE("dnd::FeaturesParser::createFeature: invalid JSON format") {

--- a/tests/parsing/models/spells_file_parser_test.cpp
+++ b/tests/parsing/models/spells_file_parser_test.cpp
@@ -11,7 +11,9 @@
 #include "controllers/groups.hpp"
 #include "models/spell.hpp"
 
-// class that allows us to test the dnd::SpellsFileParser class
+/**
+ * @brief A class that allows us to test the dnd::SpellsFileParser class
+ */
 class TestSpellsFileParser : public dnd::SpellsFileParser {
 public:
     TestSpellsFileParser(std::unordered_map<std::string, const dnd::Spell>& spells, dnd::Groups& groups)

--- a/tests/parsing/models/spells_file_parser_test.cpp
+++ b/tests/parsing/models/spells_file_parser_test.cpp
@@ -15,7 +15,7 @@
 class TestSpellsFileParser : public dnd::SpellsFileParser {
 public:
     TestSpellsFileParser(std::unordered_map<std::string, const dnd::Spell>& spells, dnd::Groups& groups)
-        : dnd::SpellsFileParser(spells, groups) {}
+        : dnd::SpellsFileParser("", spells, groups) {}
     dnd::SpellType createSpellTypeForTesting(const std::string& spell_type_str) const {
         return dnd::SpellsFileParser::createSpellType(spell_type_str);
     }


### PR DESCRIPTION
Through a bit of refactoring, it was possible to configure parsers with their filepath (and parsing type) on initialisiation.
Thereby removing the need for all the functions facilitating the correct configuration of parsers.