### PR TITLE
Improved content library

### DIFF
--- a/src/core/controllers/content_holder.cpp
+++ b/src/core/controllers/content_holder.cpp
@@ -11,7 +11,7 @@
 #include "models/feature_holder.hpp"
 
 void add_features_of_feature_holder(
-    dnd::ContentLibrary<const dnd::Feature*>& features_library, const dnd::FeatureHolder* feature_holder
+    dnd::ReferencingContentLibrary<const dnd::Feature>& features_library, const dnd::FeatureHolder* feature_holder
 ) {
     for (const auto& feature : feature_holder->features) {
         features_library.add(feature.name, &feature);
@@ -36,7 +36,7 @@ void dnd::ContentHolder::finished_parsing() {
     }
 
     for (const auto& [group_name, group_choosables] : groups.getAllChoosableGroups()) {
-        choosables[group_name] = ContentLibrary<const Choosable*>();
+        choosables[group_name] = ReferencingContentLibrary<const Choosable>();
         for (const auto& [choosable_name, choosable] : group_choosables) {
             choosables[group_name].add(choosable_name, &choosable);
         }

--- a/src/core/controllers/content_holder.hpp
+++ b/src/core/controllers/content_holder.hpp
@@ -46,16 +46,16 @@ public:
 
     // content libraries for all the types of content
 
-    ContentLibrary<Character> characters;
-    ContentLibrary<const CharacterClass> character_classes;
-    ContentLibrary<const CharacterSubclass> character_subclasses;
-    ContentLibrary<const CharacterRace> character_races;
-    ContentLibrary<const CharacterSubrace> character_subraces;
-    ContentLibrary<const Item> items;
-    ContentLibrary<const Spell> spells;
+    StoringContentLibrary<Character> characters;
+    StoringContentLibrary<const CharacterClass> character_classes;
+    StoringContentLibrary<const CharacterSubclass> character_subclasses;
+    StoringContentLibrary<const CharacterRace> character_races;
+    StoringContentLibrary<const CharacterSubrace> character_subraces;
+    StoringContentLibrary<const Item> items;
+    StoringContentLibrary<const Spell> spells;
 
-    ContentLibrary<const Feature*> features;
-    std::unordered_map<std::string, ContentLibrary<const Choosable*>> choosables;
+    ReferencingContentLibrary<const Feature> features;
+    std::unordered_map<std::string, ReferencingContentLibrary<const Choosable>> choosables;
 };
 
 inline bool ContentHolder::empty() const {

--- a/src/core/controllers/content_library.hpp
+++ b/src/core/controllers/content_library.hpp
@@ -159,6 +159,15 @@ inline std::unordered_set<TrieT*> ContentLibrary<TrieT, DataT>::prefix_get(const
 
 template <typename TrieT, typename DataT>
     requires validContentLibraryTypes<TrieT, DataT>
+inline std::vector<TrieT*> ContentLibrary<TrieT, DataT>::sorted_prefix_get(const std::string& prefix) {
+    std::unordered_set<TrieT*> unsorted_result = prefix_get(prefix);
+    std::vector<TrieT*> result(unsorted_result.begin(), unsorted_result.end());
+    std::sort(result.begin(), result.end(), [](TrieT* a, TrieT* b) { return a->name < b->name; });
+    return result;
+}
+
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
 inline const std::unordered_map<std::string, DataT>& ContentLibrary<TrieT, DataT>::get_all() const {
     return data;
 }

--- a/src/core/controllers/content_library.hpp
+++ b/src/core/controllers/content_library.hpp
@@ -13,6 +13,8 @@
 #include <unordered_set>
 #include <vector>
 
+#include <iostream>
+
 #include "controllers/searching/trie.hpp"
 #include "models/content_piece.hpp"
 
@@ -183,6 +185,7 @@ bool ContentLibrary<TrieT, DataT>::create(
     if (contains(name)) {
         return false;
     }
+    // const std::string name_copy = name;
     data.emplace(
         std::piecewise_construct, std::forward_as_tuple(name),
         std::forward_as_tuple(name, source_file_path, std::move(constructor_args)...)

--- a/src/core/controllers/content_library.hpp
+++ b/src/core/controllers/content_library.hpp
@@ -5,17 +5,29 @@
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 #include "controllers/searching/trie.hpp"
+#include "models/content_piece.hpp"
 
 namespace dnd {
 
-template <typename T>
+template <typename TrieT, typename DataT>
+concept validContentLibraryTypes = std::is_base_of_v<ContentPiece, TrieT>
+                                   && std::is_same_v<TrieT, typename std::remove_pointer<DataT>::type>;
+/**
+ * @brief A library of content pieces
+ * @tparam TrieT the trie type to use for searching
+ * @tparam DataT the data type to use for retrieving content pieces
+ */
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
 class ContentLibrary {
 public:
     /**
@@ -39,37 +51,37 @@ public:
      * @return reference to the piece of content if it exists
      * @throws std::out_of_range if the piece of content does not exist
      */
-    T& get(const std::string& name);
+    DataT& get(const std::string& name);
     /**
      * @brief Get content piece by its name
      * @return constant reference to the piece of content if it exists
      * @throws std::out_of_range if the piece of content does not exist
      */
-    const T& get(const std::string& name) const;
+    const DataT& get(const std::string& name) const;
     /**
      * @brief Get all pieces of content matching a given prefix
      * @param prefix the prefix to the name (or the prefix to one word of the whole name)
      * @return all pieces of content matching the prefix (empty if none such piece exists)
      */
-    std::unordered_set<T*> prefix_get(const std::string& prefix);
+    std::unordered_set<TrieT*> prefix_get(const std::string& prefix);
     /**
      * @brief Get all pieces of content matching a given prefix in order
      * @param prefix the prefix to the name (or the prefix to one word of the whole name)
      * @return all pieces of content matching the prefix in order (empty if none such piece exists)
      */
-    std::vector<T*> sorted_prefix_get(const std::string& prefix);
+    std::vector<TrieT*> sorted_prefix_get(const std::string& prefix);
     /**
      * @brief Get all pieces of content
      * @return the map containing the pieces of content
      */
-    const std::unordered_map<std::string, T>& get_all() const;
+    const std::unordered_map<std::string, DataT>& get_all() const;
     /**
      * @brief Add a content piece if no piece of content with the same name exists
      * @param name the name of the piece of content
      * @param new_content_piece the new piece of content
      * @return true, if piece was added, false if name already exists
      */
-    bool add(const std::string& name, T&& new_content_piece);
+    bool add(const std::string& name, DataT&& new_content_piece);
     /**
      * @brief Create a content piece inplace if no piece of content with the same name exists
      * @tparam ...Args the types the constructor for the piece of content allows
@@ -77,8 +89,10 @@ public:
      * @param ...constructor_args the constructor arguments to create the piece of content
      * @return true, if piece was created and added, false if name already exists
      */
-    template <typename... Args, std::enable_if_t<std::is_constructible<T, Args&&...>::value, int> = 0>
-    bool create(const std::string& name, Args&&... constructor_args);
+    template <
+        typename... Args,
+        std::enable_if_t<std::is_constructible<DataT, std::string&, std::filesystem::path&, Args&&...>::value, int> = 0>
+    bool create(const std::string& name, const std::filesystem::path& source_file_path, Args&&... constructor_args);
 protected:
     /**
      * @brief Saves a piece of content that already exists in the data-map into the trie under multiple names
@@ -86,47 +100,70 @@ protected:
      */
     void save_in_trie(const std::string& name);
 
-    std::unordered_map<std::string, T> data;
-    Trie<T> trie;
+    std::unordered_map<std::string, DataT> data;
+    Trie<TrieT> trie;
 };
 
+/**
+ * @brief A content library that stores the content pieces directly.
+ * @tparam T the type of the content pieces being stored
+ */
 template <typename T>
-inline bool ContentLibrary<T>::contains(const std::string& name) const {
+using StoringContentLibrary = ContentLibrary<T, T>;
+
+/**
+ * @brief A content library that stores pointers to the content pieces, which are stored elsewhere.
+ * @tparam T the type of the content pieces being referenced
+ */
+template <typename T>
+using ReferencingContentLibrary = ContentLibrary<T, T*>;
+
+
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline bool ContentLibrary<TrieT, DataT>::contains(const std::string& name) const {
     return data.contains(name);
 }
 
-template <typename T>
-inline bool ContentLibrary<T>::empty() const {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline bool ContentLibrary<TrieT, DataT>::empty() const {
     return data.empty();
 }
 
-template <typename T>
-inline size_t ContentLibrary<T>::size() const {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline size_t ContentLibrary<TrieT, DataT>::size() const {
     return data.size();
 }
 
-template <typename T>
-inline T& ContentLibrary<T>::get(const std::string& name) {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline DataT& ContentLibrary<TrieT, DataT>::get(const std::string& name) {
     return data.at(name);
 }
 
-template <typename T>
-inline const T& ContentLibrary<T>::get(const std::string& name) const {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline const DataT& ContentLibrary<TrieT, DataT>::get(const std::string& name) const {
     return data.at(name);
 }
 
-template <typename T>
-inline std::unordered_set<T*> ContentLibrary<T>::prefix_get(const std::string& prefix) {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline std::unordered_set<TrieT*> ContentLibrary<TrieT, DataT>::prefix_get(const std::string& prefix) {
     return trie.search_prefix(prefix);
 }
 
-template <typename T>
-inline const std::unordered_map<std::string, T>& ContentLibrary<T>::get_all() const {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+inline const std::unordered_map<std::string, DataT>& ContentLibrary<TrieT, DataT>::get_all() const {
     return data;
 }
 
-template <typename T>
-bool ContentLibrary<T>::add(const std::string& name, T&& new_content_piece) {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+bool ContentLibrary<TrieT, DataT>::add(const std::string& name, DataT&& new_content_piece) {
     if (contains(name)) {
         return false;
     }
@@ -135,22 +172,29 @@ bool ContentLibrary<T>::add(const std::string& name, T&& new_content_piece) {
     return true;
 }
 
-template <typename T>
-template <typename... Args, std::enable_if_t<std::is_constructible<T, Args&&...>::value, int>>
-bool ContentLibrary<T>::create(const std::string& name, Args&&... constructor_args) {
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+template <
+    typename... Args,
+    std::enable_if_t<std::is_constructible<DataT, std::string&, std::filesystem::path&, Args&&...>::value, int>>
+bool ContentLibrary<TrieT, DataT>::create(
+    const std::string& name, const std::filesystem::path& source_file_path, Args&&... constructor_args
+) {
     if (contains(name)) {
         return false;
     }
     data.emplace(
-        std::piecewise_construct, std::forward_as_tuple(name), std::forward_as_tuple(std::move(constructor_args)...)
+        std::piecewise_construct, std::forward_as_tuple(name),
+        std::forward_as_tuple(name, source_file_path, std::move(constructor_args)...)
     );
     save_in_trie(name);
     return true;
 }
 
-template <typename T>
-void ContentLibrary<T>::save_in_trie(const std::string& name) {
-    T* content_piece_ptr = &data.at(name);
+template <typename TrieT, typename DataT>
+    requires validContentLibraryTypes<TrieT, DataT>
+void ContentLibrary<TrieT, DataT>::save_in_trie(const std::string& name) {
+    DataT& content_piece_ptr = data.at(name);
 
     auto tolower = [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); };
     std::string lower_name = name;

--- a/src/core/controllers/searching/trie.hpp
+++ b/src/core/controllers/searching/trie.hpp
@@ -38,7 +38,13 @@ public:
      */
     Trie();
     /**
-     * @brief Inserts a word into the trie with the given data.
+     * @brief Inserts a word into the trie with the given data (by reference).
+     * @param word the string to insert
+     * @param data the data to associate with the end of the word
+     */
+    void insert(std::string_view word, T& data);
+    /**
+     * @brief Inserts a word into the trie with the given data (as a pointer).
      * @param word the string to insert
      * @param data the data to associate with the end of the word
      */
@@ -75,6 +81,11 @@ private:
 
 template <typename T>
 Trie<T>::Trie() : root(std::make_unique<TrieNode<T>>(TrieNode<T>())) {}
+
+template <typename T>
+inline void Trie<T>::insert(std::string_view word, T& data) {
+    insert(word, &data);
+}
 
 template <typename T>
 void Trie<T>::insert(std::string_view word, T* data) {

--- a/src/core/models/character.hpp
+++ b/src/core/models/character.hpp
@@ -32,7 +32,8 @@ public:
      * @param base_ability_scores the 6 base values for the character's ability scores
      */
     Character(
-        const std::string& name, std::vector<Feature>&& features, const std::array<int, 6>& base_ability_scores
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const std::array<int, 6>& base_ability_scores
     ) noexcept;
     /**
      * @brief Constructs a character with a given level and XP value
@@ -44,8 +45,8 @@ public:
      * @param hit_dice_rolls the values rolled for maxHP at each level-up using your hit dice (including level 1)
      */
     Character(
-        const std::string& name, std::vector<Feature>&& features, const std::array<int, 6>& base_ability_scores,
-        int level, int xp, const std::vector<int>& hit_dice_rolls
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const std::array<int, 6>& base_ability_scores, int level, int xp, const std::vector<int>& hit_dice_rolls
     ) noexcept;
     /**
      * @brief Returns the level of the character
@@ -133,20 +134,21 @@ private:
 };
 
 inline Character::Character(
-    const std::string& name, std::vector<Feature>&& features, const std::array<int, 6>& base_ability_scores
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const std::array<int, 6>& base_ability_scores
 ) noexcept
-    : FeatureHolder(name, std::move(features)), base_ability_scores(base_ability_scores), class_ptr(nullptr),
-      subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr), decisions(), state(decisions), level(1), xp(0),
-      hit_dice_rolls() {}
+    : FeatureHolder(name, source_file_path, std::move(features)), base_ability_scores(base_ability_scores),
+      class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr), decisions(), state(decisions),
+      level(1), xp(0), hit_dice_rolls() {}
 
 
 inline Character::Character(
-    const std::string& name, std::vector<Feature>&& features, const std::array<int, 6>& base_ability_scores, int level,
-    int xp, const std::vector<int>& hit_dice_rolls
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const std::array<int, 6>& base_ability_scores, int level, int xp, const std::vector<int>& hit_dice_rolls
 ) noexcept
-    : FeatureHolder(name, std::move(features)), base_ability_scores(base_ability_scores), class_ptr(nullptr),
-      subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr), decisions(), state(decisions), level(level),
-      xp(xp), hit_dice_rolls(hit_dice_rolls) {}
+    : FeatureHolder(name, source_file_path, std::move(features)), base_ability_scores(base_ability_scores),
+      class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr), decisions(), state(decisions),
+      level(level), xp(xp), hit_dice_rolls(hit_dice_rolls) {}
 
 inline int Character::getLevel() const noexcept { return level; }
 

--- a/src/core/models/character_class.hpp
+++ b/src/core/models/character_class.hpp
@@ -27,8 +27,8 @@ public:
      * @param subclass_level the level at which a character of this class gains access to subclasses
      */
     CharacterClass(
-        const std::string& name, std::vector<Feature>&& features, const Dice hit_dice,
-        const std::vector<int>& asi_levels, int subclass_level
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const Dice hit_dice, const std::vector<int>& asi_levels, int subclass_level
     ) noexcept;
 
     // the type of hit dice for this class
@@ -40,10 +40,10 @@ public:
 };
 
 inline CharacterClass::CharacterClass(
-    const std::string& name, std::vector<Feature>&& features, const Dice hit_dice, const std::vector<int>& asi_levels,
-    int subclass_level
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const Dice hit_dice, const std::vector<int>& asi_levels, int subclass_level
 ) noexcept
-    : FeatureHolder(name, std::move(features)), hit_dice(hit_dice), asi_levels(asi_levels),
+    : FeatureHolder(name, source_file_path, std::move(features)), hit_dice(hit_dice), asi_levels(asi_levels),
       subclass_level(subclass_level) {}
 
 } // namespace dnd

--- a/src/core/models/character_race.hpp
+++ b/src/core/models/character_race.hpp
@@ -23,16 +23,20 @@ public:
      * @param features a collection of features this race provides to a character
      * @param has_subraces "true" if this race has subraces, "false" otherwise
      */
-    CharacterRace(const std::string& name, std::vector<Feature>&& features, const bool has_subraces) noexcept;
+    CharacterRace(
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const bool has_subraces
+    ) noexcept;
 
     // "true" if this race has subraces, "false" otherwise
     const bool has_subraces;
 };
 
 inline CharacterRace::CharacterRace(
-    const std::string& name, std::vector<Feature>&& features, const bool has_subraces
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const bool has_subraces
 ) noexcept
-    : FeatureHolder(name, std::move(features)), has_subraces(has_subraces) {}
+    : FeatureHolder(name, source_file_path, std::move(features)), has_subraces(has_subraces) {}
 
 } // namespace dnd
 

--- a/src/core/models/character_subclass.hpp
+++ b/src/core/models/character_subclass.hpp
@@ -23,16 +23,20 @@ public:
      * @param features the collection of features this subclass provides to a character
      * @param class_name the name of the class this is a subclass of
      */
-    CharacterSubclass(const std::string& name, std::vector<Feature>&& features, const std::string& class_name) noexcept;
+    CharacterSubclass(
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const std::string& class_name
+    ) noexcept;
 
     // the name of the class this is a subclass of
     const std::string class_name;
 };
 
 inline CharacterSubclass::CharacterSubclass(
-    const std::string& name, std::vector<Feature>&& features, const std::string& class_name
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const std::string& class_name
 ) noexcept
-    : FeatureHolder(name, std::move(features)), class_name(class_name) {}
+    : FeatureHolder(name, source_file_path, std::move(features)), class_name(class_name) {}
 
 } // namespace dnd
 

--- a/src/core/models/character_subrace.hpp
+++ b/src/core/models/character_subrace.hpp
@@ -23,16 +23,20 @@ public:
      * @param features a collection of features this subrace provides to a character
      * @param race_name the name of the race this is a subrace of
      */
-    CharacterSubrace(const std::string& name, std::vector<Feature>&& features, const std::string& race_name) noexcept;
+    CharacterSubrace(
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+        const std::string& race_name
+    ) noexcept;
 
     // the name of the race this is a subrace of
     const std::string race_name;
 };
 
 inline CharacterSubrace::CharacterSubrace(
-    const std::string& name, std::vector<Feature>&& features, const std::string& race_name
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features,
+    const std::string& race_name
 ) noexcept
-    : FeatureHolder(name, std::move(features)), race_name(race_name) {}
+    : FeatureHolder(name, source_file_path, std::move(features)), race_name(race_name) {}
 
 } // namespace dnd
 

--- a/src/core/models/content_piece.hpp
+++ b/src/core/models/content_piece.hpp
@@ -1,0 +1,23 @@
+#ifndef CONTENT_PIECE_HPP_
+#define CONTENT_PIECE_HPP_
+
+#include "dnd_config.hpp"
+
+#include <filesystem>
+#include <string>
+
+namespace dnd {
+
+class ContentPiece {
+public:
+    ContentPiece(const std::string& name, const std::filesystem::path& source_file_path);
+    const std::string name;
+    const std::filesystem::path source_file_path;
+};
+
+inline ContentPiece::ContentPiece(const std::string& name, const std::filesystem::path& source_file_path)
+    : name(name), source_file_path(source_file_path) {}
+
+} // namespace dnd
+
+#endif // CONTENT_PIECE_HPP_

--- a/src/core/models/effect_holder/choosable.hpp
+++ b/src/core/models/effect_holder/choosable.hpp
@@ -3,10 +3,12 @@
 
 #include "dnd_config.hpp"
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "models/content_piece.hpp"
 #include "models/effect_holder/effect_holder.hpp"
 #include "models/effect_holder/prerequisite.hpp"
 
@@ -15,18 +17,18 @@ namespace dnd {
 /**
  * @brief A class representing feature-like objects a character can choose to have such as feats or eldritch invocations
  */
-class Choosable {
+class Choosable : public ContentPiece {
 public:
     /**
      * @brief Constructs a choosable with its name and description
      * @param name the name of the choosable
      * @param description a human-readable description of what the choosable provides
      */
-    Choosable(const std::string& name, const std::string& description) noexcept;
+    Choosable(
+        const std::string& name, const std::filesystem::path& source_file_path, const std::string& description
+    ) noexcept;
     Choosable(Choosable&& other) noexcept = default;
 
-    // the name of the choosable
-    const std::string name;
     // a human-readable description of what the choosable provides
     const std::string description;
     // the prerequisites a character must fulfill to be able to choose this choosable
@@ -37,8 +39,10 @@ public:
     std::vector<EffectHolder> parts;
 };
 
-inline Choosable::Choosable(const std::string& name, const std::string& description) noexcept
-    : name(name), description(description) {}
+inline Choosable::Choosable(
+    const std::string& name, const std::filesystem::path& source_file_path, const std::string& description
+) noexcept
+    : ContentPiece(name, source_file_path), description(description) {}
 
 } // namespace dnd
 

--- a/src/core/models/effect_holder/feature.hpp
+++ b/src/core/models/effect_holder/feature.hpp
@@ -3,9 +3,11 @@
 
 #include "dnd_config.hpp"
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
+#include "models/content_piece.hpp"
 #include "models/effect_holder/effect_holder.hpp"
 #include "models/effect_holder/effect_holder_with_choices.hpp"
 
@@ -14,14 +16,16 @@ namespace dnd {
 /**
  * @brief A class representing a feature provided by classes, races, subclasses and subraces
  */
-class Feature {
+class Feature : public ContentPiece {
 public:
     /**
      * @brief Constructs a feature with its name and description
      * @param name the name of the feature
      * @param description a human-readable description of what the feature provides
      */
-    Feature(const std::string& name, const std::string& description) noexcept;
+    Feature(
+        const std::string& name, const std::filesystem::path& source_file_path, const std::string& description
+    ) noexcept;
     Feature(Feature&& other) noexcept = default;
     /**
      * @brief Checks whether the feature is active (provides its effects) for a character of a certain level
@@ -45,8 +49,10 @@ public:
     std::vector<EffectHolderWithChoices> parts_with_choices;
 };
 
-inline Feature::Feature(const std::string& name, const std::string& description) noexcept
-    : name(name), description(description), subclass(false) {}
+inline Feature::Feature(
+    const std::string& name, const std::filesystem::path& source_file_path, const std::string& description
+) noexcept
+    : ContentPiece(name, source_file_path), description(description), subclass(false) {}
 
 } // namespace dnd
 

--- a/src/core/models/effect_holder/feature.hpp
+++ b/src/core/models/effect_holder/feature.hpp
@@ -35,8 +35,6 @@ public:
      */
     bool isActiveForLevel(int level) const;
 
-    // the name of the feature
-    const std::string name;
     // a human-readable description of what the feature provides
     const std::string description;
     // set to true, if this is a class feature providing you access to subclasses

--- a/src/core/models/feature_holder.hpp
+++ b/src/core/models/feature_holder.hpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "models/content_piece.hpp"
 #include "models/effect_holder/feature.hpp"
 
 namespace dnd {
@@ -14,14 +15,16 @@ namespace dnd {
 /**
  * @brief A class representing all types of bodies that provide features to characters i.e. (sub)classes and (sub)races
  */
-class FeatureHolder {
+class FeatureHolder : public ContentPiece {
 public:
     /**
      * @brief Constructs a feature holder with a name and with features
      * @param name the name of the feature holder
      * @param features a collection of features this holder provides to a character of its type
      */
-    FeatureHolder(const std::string& name, std::vector<Feature>&& features) noexcept;
+    FeatureHolder(
+        const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features
+    ) noexcept;
     virtual ~FeatureHolder() noexcept = default;
 
     // the name of the feature holder
@@ -30,8 +33,10 @@ public:
     const std::vector<Feature> features;
 };
 
-inline FeatureHolder::FeatureHolder(const std::string& name, std::vector<Feature>&& features) noexcept
-    : name(name), features(std::move(features)) {}
+inline FeatureHolder::FeatureHolder(
+    const std::string& name, const std::filesystem::path& source_file_path, std::vector<Feature>&& features
+) noexcept
+    : ContentPiece(name, source_file_path), features(std::move(features)) {}
 
 } // namespace dnd
 

--- a/src/core/models/feature_holder.hpp
+++ b/src/core/models/feature_holder.hpp
@@ -27,8 +27,6 @@ public:
     ) noexcept;
     virtual ~FeatureHolder() noexcept = default;
 
-    // the name of the feature holder
-    const std::string name;
     // a collection of features this holder provides to a character of its type
     const std::vector<Feature> features;
 };

--- a/src/core/models/item.hpp
+++ b/src/core/models/item.hpp
@@ -36,7 +36,6 @@ public:
         const std::string description, const std::string cosmetic_description
     ) noexcept;
 
-    const std::string name;
     const bool requires_attunement;
     // a functional description of the item (how it works and what it does)
     const std::string description;

--- a/src/core/models/item.hpp
+++ b/src/core/models/item.hpp
@@ -5,12 +5,14 @@
 
 #include <string>
 
+#include "models/content_piece.hpp"
+
 namespace dnd {
 
 /**
  * @brief A class representing an item (something a character can equip)
  */
-class Item {
+class Item : public ContentPiece {
 public:
     /**
      * @brief Constructs an item (without cosmetic description)
@@ -18,7 +20,10 @@ public:
      * @param requires_attunement whether the item requires attunement
      * @param description a description of how the item works and/or what is does
      */
-    Item(const std::string& name, bool requires_attunement, const std::string description) noexcept;
+    Item(
+        const std::string& name, const std::filesystem::path& source_file_path, bool requires_attunement,
+        const std::string description
+    ) noexcept;
     /**
      * @brief Constructs an item with cosmetic description
      * @param name the name of the item
@@ -27,8 +32,8 @@ public:
      * @param cosmetic_description a description of the purely cosmetic (non-functional) aspects of the item
      */
     Item(
-        const std::string& name, bool requires_attunement, const std::string description,
-        const std::string cosmetic_description
+        const std::string& name, const std::filesystem::path& source_file_path, bool requires_attunement,
+        const std::string description, const std::string cosmetic_description
     ) noexcept;
 
     const std::string name;
@@ -39,14 +44,18 @@ public:
     const std::string cosmetic_description;
 };
 
-inline Item::Item(const std::string& name, bool requires_attunement, const std::string description) noexcept
-    : name(name), requires_attunement(requires_attunement), description(description), cosmetic_description() {}
+inline Item::Item(
+    const std::string& name, const std::filesystem::path& source_file_path, bool requires_attunement,
+    const std::string description
+) noexcept
+    : ContentPiece(name, source_file_path), requires_attunement(requires_attunement), description(description),
+      cosmetic_description() {}
 
 inline Item::Item(
-    const std::string& name, bool requires_attunement, const std::string description,
-    const std::string cosmetic_description
+    const std::string& name, const std::filesystem::path& source_file_path, bool requires_attunement,
+    const std::string description, const std::string cosmetic_description
 ) noexcept
-    : name(name), requires_attunement(requires_attunement), description(description),
+    : ContentPiece(name, source_file_path), requires_attunement(requires_attunement), description(description),
       cosmetic_description(cosmetic_description) {}
 
 } // namespace dnd

--- a/src/core/models/spell.hpp
+++ b/src/core/models/spell.hpp
@@ -155,8 +155,6 @@ public:
         const std::string& duration, const std::string& description, const std::unordered_set<std::string>& classes
     ) noexcept;
 
-    // the name of the spell
-    const std::string name;
     // a description of how long the spell takes to cast
     const std::string casting_time;
     // a description of the range of the spell

--- a/src/core/models/spell.hpp
+++ b/src/core/models/spell.hpp
@@ -10,6 +10,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include "models/content_piece.hpp"
+
 namespace dnd {
 
 /**
@@ -134,7 +136,7 @@ struct SpellComponents {
 /**
  * @brief A class representing a spell
  */
-class Spell {
+class Spell : public ContentPiece {
 public:
     /**
      * @brief Constructs a spell
@@ -148,9 +150,9 @@ public:
      * @param classes the names of classes (and subclasses) that can cast this spell
      */
     Spell(
-        const std::string& name, const SpellType& type, const std::string& casting_time, const std::string& range,
-        const SpellComponents& components, const std::string& duration, const std::string& description,
-        const std::unordered_set<std::string>& classes
+        const std::string& name, const std::filesystem::path& source_file_path, const SpellType& type,
+        const std::string& casting_time, const std::string& range, const SpellComponents& components,
+        const std::string& duration, const std::string& description, const std::unordered_set<std::string>& classes
     ) noexcept;
 
     // the name of the spell
@@ -172,12 +174,12 @@ public:
 };
 
 inline Spell::Spell(
-    const std::string& name, const SpellType& type, const std::string& casting_time, const std::string& range,
-    const SpellComponents& components, const std::string& duration, const std::string& description,
-    const std::unordered_set<std::string>& classes
+    const std::string& name, const std::filesystem::path& source_file_path, const SpellType& type,
+    const std::string& casting_time, const std::string& range, const SpellComponents& components,
+    const std::string& duration, const std::string& description, const std::unordered_set<std::string>& classes
 ) noexcept
-    : name(name), casting_time(casting_time), range(range), duration(duration), description(description),
-      classes(classes), type(type), components(components) {}
+    : ContentPiece(name, source_file_path), casting_time(casting_time), range(range), duration(duration),
+      description(description), classes(classes), type(type), components(components) {}
 
 } // namespace dnd
 

--- a/src/core/parsing/controllers/content_parser.cpp
+++ b/src/core/parsing/controllers/content_parser.cpp
@@ -82,7 +82,7 @@ dnd::ContentHolder dnd::ContentParser::parse(
         parseAllOfType(ParsingType::RACE);
         parseAllOfType(ParsingType::SUBCLASS);
         parseAllOfType(ParsingType::SUBRACE);
-        // parseAllOfType(ParsingType::CHARACTER);
+        parseAllOfType(ParsingType::CHARACTER);
     } catch (parsing_error& e) {
         e.relativiseFileName(content_path);
         throw e;

--- a/src/core/parsing/controllers/content_parser.cpp
+++ b/src/core/parsing/controllers/content_parser.cpp
@@ -82,7 +82,7 @@ dnd::ContentHolder dnd::ContentParser::parse(
         parseAllOfType(ParsingType::RACE);
         parseAllOfType(ParsingType::SUBCLASS);
         parseAllOfType(ParsingType::SUBRACE);
-        parseAllOfType(ParsingType::CHARACTER);
+        // parseAllOfType(ParsingType::CHARACTER);
     } catch (parsing_error& e) {
         e.relativiseFileName(content_path);
         throw e;

--- a/src/core/parsing/controllers/effect_holder_groups_file_parser.cpp
+++ b/src/core/parsing/controllers/effect_holder_groups_file_parser.cpp
@@ -39,7 +39,7 @@ dnd::Choosable dnd::EffectHolderGroupsFileParser::createChoosable(
     const std::string description = choosable_json.at("description").get<std::string>();
 
     // TODO: change choosable constructor?
-    Choosable choosable(choosable_name, description);
+    Choosable choosable(choosable_name, filepath, description);
 
     choosable.main_part = effect_holder_parser.createEffectHolder(choosable_json);
     if (choosable_json.contains("multi")) {

--- a/src/core/parsing/models/character_class_file_parser.cpp
+++ b/src/core/parsing/models/character_class_file_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "character_class_file_parser.hpp"
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -75,8 +76,8 @@ bool dnd::CharacterClassFileParser::validate() const {
 
 void dnd::CharacterClassFileParser::saveResult() {
     classes.create(
-        character_class_name, character_class_name, std::move(features_parser.retrieveFeatures()),
-        character_class_hit_dice, asi_levels, subclass_level
+        character_class_name, filepath, std::move(features_parser.retrieveFeatures()), character_class_hit_dice,
+        asi_levels, subclass_level
     );
     // TODO: add spellcasting
 }

--- a/src/core/parsing/models/character_class_file_parser.hpp
+++ b/src/core/parsing/models/character_class_file_parser.hpp
@@ -33,8 +33,8 @@ public:
      * @param spells the already-parsed spells
      */
     CharacterClassFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<const CharacterClass>& classes, const Groups& groups,
-        const ContentLibrary<const Spell>& spells
+        const std::filesystem::path& filepath, StoringContentLibrary<const CharacterClass>& classes, const Groups& groups,
+        const StoringContentLibrary<const Spell>& spells
     ) noexcept;
     /**
      * @brief Parses JSON file containing a class
@@ -76,7 +76,7 @@ private:
     // the subclass level of the parsed class
     int subclass_level;
     // the already-parsed classes to add the parsed class to
-    ContentLibrary<const CharacterClass>& classes;
+    StoringContentLibrary<const CharacterClass>& classes;
     // a subparser used for parsing the class' features
     FeaturesParser features_parser;
     // a subparser used for parsing the subclass' spellcasting feature if it exists
@@ -84,8 +84,8 @@ private:
 };
 
 inline CharacterClassFileParser::CharacterClassFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const CharacterClass>& classes, const Groups& groups,
-    const ContentLibrary<const Spell>& spells
+    const std::filesystem::path& filepath, StoringContentLibrary<const CharacterClass>& classes, const Groups& groups,
+    const StoringContentLibrary<const Spell>& spells
 ) noexcept
     : ContentFileParser(filepath), classes(classes), features_parser(type, filepath, groups),
       spellcasting_parser(type, filepath, spells) {}

--- a/src/core/parsing/models/character_file_parser.cpp
+++ b/src/core/parsing/models/character_file_parser.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <filesystem>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -276,7 +277,7 @@ bool dnd::CharacterFileParser::validate() const {
 void dnd::CharacterFileParser::saveResult() {
     // TODO: change Character constructor
     characters.create(
-        character_name, character_name, std::move(features_parser.retrieveFeatures()), base_ability_scores, level, xp,
+        character_name, filepath, std::move(features_parser.retrieveFeatures()), base_ability_scores, level, xp,
         hit_dice_rolls
     );
     Character& character = characters.get(character_name);

--- a/src/core/parsing/models/character_file_parser.hpp
+++ b/src/core/parsing/models/character_file_parser.hpp
@@ -42,11 +42,12 @@ public:
      * @param spells the already-parsed spells
      */
     CharacterFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<Character>& characters, const Groups& groups,
-        const ContentLibrary<const CharacterClass>& character_classes,
-        const ContentLibrary<const CharacterSubclass>& character_subclasses,
-        const ContentLibrary<const CharacterRace>& character_races,
-        const ContentLibrary<const CharacterSubrace>& character_subraces, const ContentLibrary<const Spell>& spells
+        const std::filesystem::path& filepath, StoringContentLibrary<Character>& characters, const Groups& groups,
+        const StoringContentLibrary<const CharacterClass>& character_classes,
+        const StoringContentLibrary<const CharacterSubclass>& character_subclasses,
+        const StoringContentLibrary<const CharacterRace>& character_races,
+        const StoringContentLibrary<const CharacterSubrace>& character_subraces,
+        const StoringContentLibrary<const Spell>& spells
     ) noexcept;
     /**
      * @brief Parses JSON file containing a character
@@ -119,17 +120,17 @@ private:
     // the XP value of the parsed character
     int xp;
     // the already-parsed characters to add the parsed character to
-    ContentLibrary<Character>& characters;
+    StoringContentLibrary<Character>& characters;
     // the already-parsed classes to find the parsed character's class
-    const ContentLibrary<const CharacterClass>& character_classes;
+    const StoringContentLibrary<const CharacterClass>& character_classes;
     // the already-parsed classes to find the parsed character's subclass
-    const ContentLibrary<const CharacterSubclass>& character_subclasses;
+    const StoringContentLibrary<const CharacterSubclass>& character_subclasses;
     // the already-parsed classes to find the parsed character's race
-    const ContentLibrary<const CharacterRace>& character_races;
+    const StoringContentLibrary<const CharacterRace>& character_races;
     // the already-parsed classes to find the parsed character's subrace
-    const ContentLibrary<const CharacterSubrace>& character_subraces;
+    const StoringContentLibrary<const CharacterSubrace>& character_subraces;
     // the already-parsed spells
-    const ContentLibrary<const Spell>& spells;
+    const StoringContentLibrary<const Spell>& spells;
     // a subparser for effect holders used for parsing the effect holders for the character decisions
     EffectHolderParser effect_holder_parser;
     // a subparser used for parsing the character's features
@@ -137,11 +138,12 @@ private:
 };
 
 inline CharacterFileParser::CharacterFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<Character>& characters, const Groups& groups,
-    const ContentLibrary<const CharacterClass>& character_classes,
-    const ContentLibrary<const CharacterSubclass>& character_subclasses,
-    const ContentLibrary<const CharacterRace>& character_races,
-    const ContentLibrary<const CharacterSubrace>& character_subraces, const ContentLibrary<const Spell>& spells
+    const std::filesystem::path& filepath, StoringContentLibrary<Character>& characters, const Groups& groups,
+    const StoringContentLibrary<const CharacterClass>& character_classes,
+    const StoringContentLibrary<const CharacterSubclass>& character_subclasses,
+    const StoringContentLibrary<const CharacterRace>& character_races,
+    const StoringContentLibrary<const CharacterSubrace>& character_subraces,
+    const StoringContentLibrary<const Spell>& spells
 ) noexcept
     : ContentFileParser(filepath), class_ptr(nullptr), subclass_ptr(nullptr), race_ptr(nullptr), subrace_ptr(nullptr),
       characters(characters), character_classes(character_classes), character_subclasses(character_subclasses),

--- a/src/core/parsing/models/character_race_file_parser.cpp
+++ b/src/core/parsing/models/character_race_file_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "character_race_file_parser.hpp"
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -38,5 +39,5 @@ bool dnd::CharacterRaceFileParser::validate() const {
 }
 
 void dnd::CharacterRaceFileParser::saveResult() {
-    races.create(character_race_name, character_race_name, std::move(features_parser.retrieveFeatures()), has_subraces);
+    races.create(character_race_name, filepath, std::move(features_parser.retrieveFeatures()), has_subraces);
 }

--- a/src/core/parsing/models/character_race_file_parser.hpp
+++ b/src/core/parsing/models/character_race_file_parser.hpp
@@ -27,7 +27,7 @@ public:
      * @param groups the already-parsed groups
      */
     CharacterRaceFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<const CharacterRace>& races, const Groups& groups
+        const std::filesystem::path& filepath, StoringContentLibrary<const CharacterRace>& races, const Groups& groups
     ) noexcept;
     /**
      * @brief Parses JSON file containing a race
@@ -58,13 +58,13 @@ private:
     // boolean for whether the parsed race has subraces
     bool has_subraces;
     // the already-parsed races to add the parsed race to
-    ContentLibrary<const CharacterRace>& races;
+    StoringContentLibrary<const CharacterRace>& races;
     // a subparser used for parsing the race's features
     FeaturesParser features_parser;
 };
 
 inline CharacterRaceFileParser::CharacterRaceFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const CharacterRace>& races, const Groups& groups
+    const std::filesystem::path& filepath, StoringContentLibrary<const CharacterRace>& races, const Groups& groups
 ) noexcept
     : ContentFileParser(filepath), races(races), features_parser(type, filepath, groups) {}
 

--- a/src/core/parsing/models/character_subclass_file_parser.cpp
+++ b/src/core/parsing/models/character_subclass_file_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "character_subclass_file_parser.hpp"
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -47,8 +48,6 @@ bool dnd::CharacterSubclassFileParser::validate() const {
 }
 
 void dnd::CharacterSubclassFileParser::saveResult() {
-    subclasses.create(
-        character_subclass_name, character_subclass_name, std::move(features_parser.retrieveFeatures()), class_name
-    );
+    subclasses.create(character_subclass_name, filepath, std::move(features_parser.retrieveFeatures()), class_name);
     // TODO: add spellcasting
 }

--- a/src/core/parsing/models/character_subclass_file_parser.hpp
+++ b/src/core/parsing/models/character_subclass_file_parser.hpp
@@ -31,9 +31,9 @@ public:
      * @param spells the already-parsed spells
      */
     CharacterSubclassFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<const CharacterSubclass>& subclasses,
-        const Groups& groups, const ContentLibrary<const CharacterClass>& classes,
-        const ContentLibrary<const Spell>& spells
+        const std::filesystem::path& filepath, StoringContentLibrary<const CharacterSubclass>& subclasses,
+        const Groups& groups, const StoringContentLibrary<const CharacterClass>& classes,
+        const StoringContentLibrary<const Spell>& spells
     ) noexcept;
     /**
      * @brief Parses JSON file containing a subclass
@@ -65,9 +65,9 @@ private:
     // the name of the class for the parsed subclass
     std::string class_name;
     // the already-parsed subclasses to add the parsed subclass to
-    ContentLibrary<const CharacterSubclass>& subclasses;
+    StoringContentLibrary<const CharacterSubclass>& subclasses;
     // the already-parsed classes to check whether such a class exists
-    const ContentLibrary<const CharacterClass>& classes;
+    const StoringContentLibrary<const CharacterClass>& classes;
     // a subparser used for parsing the subclass' features
     FeaturesParser features_parser;
     // a subparser used for parsing the subclass' spellcasting feature if it exists
@@ -75,8 +75,9 @@ private:
 };
 
 inline CharacterSubclassFileParser::CharacterSubclassFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const CharacterSubclass>& subclasses, const Groups& groups,
-    const ContentLibrary<const CharacterClass>& classes, const ContentLibrary<const Spell>& spells
+    const std::filesystem::path& filepath, StoringContentLibrary<const CharacterSubclass>& subclasses,
+    const Groups& groups, const StoringContentLibrary<const CharacterClass>& classes,
+    const StoringContentLibrary<const Spell>& spells
 ) noexcept
     : ContentFileParser(filepath), subclasses(subclasses), classes(classes), features_parser(type, filepath, groups),
       spellcasting_parser(type, filepath, spells) {}

--- a/src/core/parsing/models/character_subrace_file_parser.cpp
+++ b/src/core/parsing/models/character_subrace_file_parser.cpp
@@ -2,6 +2,7 @@
 
 #include "character_subrace_file_parser.hpp"
 
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <tuple>
@@ -45,7 +46,5 @@ bool dnd::CharacterSubraceFileParser::validate() const {
 }
 
 void dnd::CharacterSubraceFileParser::saveResult() {
-    subraces.create(
-        character_subrace_name, character_subrace_name, std::move(features_parser.retrieveFeatures()), race_name
-    );
+    subraces.create(character_subrace_name, filepath, std::move(features_parser.retrieveFeatures()), race_name);
 }

--- a/src/core/parsing/models/character_subrace_file_parser.hpp
+++ b/src/core/parsing/models/character_subrace_file_parser.hpp
@@ -30,8 +30,8 @@ public:
      * @param races the already-parsed races
      */
     CharacterSubraceFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<const CharacterSubrace>& subraces, const Groups& groups,
-        const ContentLibrary<const CharacterRace>& races
+        const std::filesystem::path& filepath, StoringContentLibrary<const CharacterSubrace>& subraces,
+        const Groups& groups, const StoringContentLibrary<const CharacterRace>& races
     ) noexcept;
     /**
      * @brief Parses JSON file containing a subrace
@@ -63,16 +63,16 @@ private:
     // the name of the race for the parsed subrace
     std::string race_name;
     // the already-parsed subraces to add the parsed subrace to
-    ContentLibrary<const CharacterSubrace>& subraces;
+    StoringContentLibrary<const CharacterSubrace>& subraces;
     // the already-parsed races to check whether such a race exists and has subraces
-    const ContentLibrary<const CharacterRace>& races;
+    const StoringContentLibrary<const CharacterRace>& races;
     // a subparser used for parsing the subrace's features
     FeaturesParser features_parser;
 };
 
 inline CharacterSubraceFileParser::CharacterSubraceFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const CharacterSubrace>& subraces, const Groups& groups,
-    const ContentLibrary<const CharacterRace>& races
+    const std::filesystem::path& filepath, StoringContentLibrary<const CharacterSubrace>& subraces,
+    const Groups& groups, const StoringContentLibrary<const CharacterRace>& races
 ) noexcept
     : ContentFileParser(filepath), subraces(subraces), races(races), features_parser(type, filepath, groups) {}
 

--- a/src/core/parsing/models/effect_holder/features_parser.cpp
+++ b/src/core/parsing/models/effect_holder/features_parser.cpp
@@ -33,7 +33,7 @@ dnd::Feature dnd::FeaturesParser::createFeature(const std::string& feature_name,
     const std::string description = feature_json.at("description").get<std::string>();
 
     // TODO: change feature constructor?
-    Feature feature(feature_name, description);
+    Feature feature(feature_name, filepath, description);
 
     feature.main_part = effect_holder_parser.createEffectHolder(feature_json);
     if (feature_json.contains("choose")) {

--- a/src/core/parsing/models/items_file_parser.cpp
+++ b/src/core/parsing/models/items_file_parser.cpp
@@ -70,7 +70,10 @@ void dnd::ItemsFileParser::saveResult() {
                 groups.add("items without attunement", info.name);
             }
 
-            items.add(info.name, Item(info.name, info.requires_attunement, info.description, info.cosmetic_description));
+            items.add(
+                info.name,
+                Item(info.name, filepath, info.requires_attunement, info.description, info.cosmetic_description)
+            );
         }
     }
 }

--- a/src/core/parsing/models/items_file_parser.cpp
+++ b/src/core/parsing/models/items_file_parser.cpp
@@ -70,10 +70,7 @@ void dnd::ItemsFileParser::saveResult() {
                 groups.add("items without attunement", info.name);
             }
 
-            items.add(
-                info.name,
-                Item(info.name, filepath, info.requires_attunement, info.description, info.cosmetic_description)
-            );
+            items.create(info.name, filepath, info.requires_attunement, info.description, info.cosmetic_description);
         }
     }
 }

--- a/src/core/parsing/models/items_file_parser.hpp
+++ b/src/core/parsing/models/items_file_parser.hpp
@@ -33,7 +33,9 @@ struct ItemParsingInfo {
  */
 class ItemsFileParser : public ContentFileParser {
 public:
-    ItemsFileParser(const std::filesystem::path& filepath, ContentLibrary<const Item>& items, Groups& groups) noexcept;
+    ItemsFileParser(
+        const std::filesystem::path& filepath, StoringContentLibrary<const Item>& items, Groups& groups
+    ) noexcept;
     /**
      * @brief Parses JSON file containing a collection of spells
      * @throws parsing_error if any error occured while trying to parse the content file
@@ -61,7 +63,7 @@ private:
     // the type of content that this parser parses - items
     static constexpr ParsingType type = ParsingType::ITEM;
     // the already-parsed items to add the parsed items to
-    ContentLibrary<const Item>& items;
+    StoringContentLibrary<const Item>& items;
     // the already-parsed groups to add item-groups to
     Groups& groups;
     // the amount of items to be parsed in the current file
@@ -73,7 +75,7 @@ private:
 };
 
 inline ItemsFileParser::ItemsFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const Item>& items, Groups& groups
+    const std::filesystem::path& filepath, StoringContentLibrary<const Item>& items, Groups& groups
 ) noexcept
     : ContentFileParser(filepath), items(items), groups(groups) {}
 

--- a/src/core/parsing/models/spellcasting/spellcasting_parser.hpp
+++ b/src/core/parsing/models/spellcasting/spellcasting_parser.hpp
@@ -36,7 +36,7 @@ public:
      * @param spells the already-parsed spells
      */
     SpellcastingParser(
-        ParsingType type, const std::filesystem::path& filepath, const ContentLibrary<const Spell>& spells
+        ParsingType type, const std::filesystem::path& filepath, const StoringContentLibrary<const Spell>& spells
     ) noexcept;
     /**
      * @brief Parses the spellcasting feature from a given JSON
@@ -64,7 +64,7 @@ private:
     void parseSize20Array(const nlohmann::json& json_to_parse, const char* attribute_name, std::array<int, 20>& output);
 
     // the already-parsed spells to look up spell lists in
-    const ContentLibrary<const Spell>& spells;
+    const StoringContentLibrary<const Spell>& spells;
     // the parsed spellcasting ability
     std::string ability;
     // the parsed ritual_casting value for the spellcasting
@@ -84,7 +84,7 @@ private:
 };
 
 inline SpellcastingParser::SpellcastingParser(
-    ParsingType type, const std::filesystem::path& filepath, const ContentLibrary<const Spell>& spells
+    ParsingType type, const std::filesystem::path& filepath, const StoringContentLibrary<const Spell>& spells
 ) noexcept
     : Subparser(type, filepath), spells(spells) {}
 

--- a/src/core/parsing/models/spells_file_parser.cpp
+++ b/src/core/parsing/models/spells_file_parser.cpp
@@ -168,11 +168,9 @@ void dnd::SpellsFileParser::saveResult() {
                 groups.add(class_name + ' ' + level_group_name, info.name);
             }
 
-            spells.add(
-                info.name, Spell(
-                               info.name, filepath, info.type, info.casting_time, info.range, info.components,
-                               info.duration, info.description, info.classes
-                           )
+            spells.create(
+                info.name, filepath, info.type, info.casting_time, info.range, info.components, info.duration,
+                info.description, info.classes
             );
         }
     }

--- a/src/core/parsing/models/spells_file_parser.cpp
+++ b/src/core/parsing/models/spells_file_parser.cpp
@@ -170,8 +170,8 @@ void dnd::SpellsFileParser::saveResult() {
 
             spells.add(
                 info.name, Spell(
-                               info.name, info.type, info.casting_time, info.range, info.components, info.duration,
-                               info.description, info.classes
+                               info.name, filepath, info.type, info.casting_time, info.range, info.components,
+                               info.duration, info.description, info.classes
                            )
             );
         }

--- a/src/core/parsing/models/spells_file_parser.hpp
+++ b/src/core/parsing/models/spells_file_parser.hpp
@@ -55,7 +55,7 @@ public:
      * @param groups the already-parsed groups
      */
     SpellsFileParser(
-        const std::filesystem::path& filepath, ContentLibrary<const Spell>& spells, Groups& groups
+        const std::filesystem::path& filepath, StoringContentLibrary<const Spell>& spells, Groups& groups
     ) noexcept;
     /**
      * @brief Parses JSON file containing a collection of spells
@@ -114,7 +114,7 @@ private:
     // the regular expression to check the validity of a spell type
     const std::regex spell_type_regex;
     // the already-parsed spells to add the parsed spells to
-    ContentLibrary<const Spell>& spells;
+    StoringContentLibrary<const Spell>& spells;
     // the already-parsed groups to add spell-groups to
     Groups& groups;
     // the amount of spells to be parsed in the current file
@@ -128,7 +128,7 @@ private:
 };
 
 inline SpellsFileParser::SpellsFileParser(
-    const std::filesystem::path& filepath, ContentLibrary<const Spell>& spells, Groups& groups
+    const std::filesystem::path& filepath, StoringContentLibrary<const Spell>& spells, Groups& groups
 ) noexcept
     : ContentFileParser(filepath), spell_components_regex(spell_type_regex_cstr),
       spell_type_regex(spell_components_regex_cstr), spells(spells), groups(groups) {}

--- a/src/gui_app/gui_app.cpp
+++ b/src/gui_app/gui_app.cpp
@@ -302,6 +302,10 @@ void dnd::GUIApp::render_search_window() {
     size_t i = 0;
     ImGui::Text("=== SPELLS ========================");
     for (const auto spell_ptr : search_result.spells) {
+        if (spell_ptr->name.empty()) {
+            ImGui::Text("empty spell %s", std::to_string(reinterpret_cast<std::uintptr_t>(spell_ptr)).c_str());
+            continue;
+        }
         if (ImGui::Selectable(spell_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }
@@ -309,6 +313,10 @@ void dnd::GUIApp::render_search_window() {
     }
     ImGui::Text("=== ITEMS =========================");
     for (const auto item_ptr : search_result.items) {
+        if (item_ptr->name.empty()) {
+            ImGui::Text("empty item %s", std::to_string(reinterpret_cast<std::uintptr_t>(item_ptr)).c_str());
+            continue;
+        }
         if (ImGui::Selectable(item_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }
@@ -316,6 +324,10 @@ void dnd::GUIApp::render_search_window() {
     }
     ImGui::Text("=== FEATURES ======================");
     for (const auto feature_ptr : search_result.features) {
+        if (feature_ptr->name.empty()) {
+            ImGui::Text("empty feature %s", std::to_string(reinterpret_cast<std::uintptr_t>(feature_ptr)).c_str());
+            continue;
+        }
         if (ImGui::Selectable(feature_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }

--- a/src/gui_app/gui_app.cpp
+++ b/src/gui_app/gui_app.cpp
@@ -279,12 +279,9 @@ void dnd::GUIApp::render_search_window() {
         if (search_query.size() > 1) {
             auto tolower = [](unsigned char c) { return static_cast<unsigned char>(std::tolower(c)); };
             std::transform(search_query.begin(), search_query.end(), search_query.begin(), tolower);
-            std::unordered_set<const Spell*> spell_result = content.spells.prefix_get(search_query);
-            search_result.spells = std::vector<const Spell*>(spell_result.begin(), spell_result.end());
-            std::unordered_set<const Item*> item_result = content.items.prefix_get(search_query);
-            search_result.items = std::vector<const Item*>(item_result.begin(), item_result.end());
-            std::unordered_set<const Feature*> feature_result = content.features.prefix_get(search_query);
-            search_result.features = std::vector<const Feature*>(feature_result.begin(), feature_result.end());
+            search_result.spells = content.spells.sorted_prefix_get(search_query);
+            search_result.items = content.items.sorted_prefix_get(search_query);
+            search_result.features = content.features.sorted_prefix_get(search_query);
         }
     }
     if (search_query.size() < 2) {

--- a/src/gui_app/gui_app.cpp
+++ b/src/gui_app/gui_app.cpp
@@ -283,8 +283,8 @@ void dnd::GUIApp::render_search_window() {
             search_result.spells = std::vector<const Spell*>(spell_result.begin(), spell_result.end());
             std::unordered_set<const Item*> item_result = content.items.prefix_get(search_query);
             search_result.items = std::vector<const Item*>(item_result.begin(), item_result.end());
-            std::unordered_set<const Feature**> feature_result = content.features.prefix_get(search_query);
-            search_result.features = std::vector<const Feature**>(feature_result.begin(), feature_result.end());
+            std::unordered_set<const Feature*> feature_result = content.features.prefix_get(search_query);
+            search_result.features = std::vector<const Feature*>(feature_result.begin(), feature_result.end());
         }
     }
     if (search_query.size() < 2) {
@@ -316,7 +316,7 @@ void dnd::GUIApp::render_search_window() {
     }
     ImGui::Text("=== FEATURES ======================");
     for (const auto feature_ptr : search_result.features) {
-        if (ImGui::Selectable((*feature_ptr)->name.c_str(), false)) {
+        if (ImGui::Selectable(feature_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }
         ++i;
@@ -331,12 +331,12 @@ void dnd::GUIApp::render_content_window() {
         for (size_t i = 0; i < selected_search_results.size(); ++i) {
             if (selected_search_results[i]) {
                 if (i < search_result.spells.size()) {
-                    render_spell_tab(search_result.spells.at(i), i);
+                    render_spell_tab(search_result.spells[i], i);
                 } else if (i < search_result.spells.size() + search_result.items.size()) {
-                    render_item_tab(search_result.items.at(i - search_result.spells.size()), i);
+                    render_item_tab(search_result.items[i - search_result.spells.size()], i);
                 } else {
                     render_feature_tab(
-                        *search_result.features.at(i - search_result.spells.size() - search_result.items.size()), i
+                        search_result.features[i - search_result.spells.size() - search_result.items.size()], i
                     );
                 }
             }

--- a/src/gui_app/gui_app.cpp
+++ b/src/gui_app/gui_app.cpp
@@ -299,10 +299,6 @@ void dnd::GUIApp::render_search_window() {
     size_t i = 0;
     ImGui::Text("=== SPELLS ========================");
     for (const auto spell_ptr : search_result.spells) {
-        if (spell_ptr->name.empty()) {
-            ImGui::Text("empty spell %s", std::to_string(reinterpret_cast<std::uintptr_t>(spell_ptr)).c_str());
-            continue;
-        }
         if (ImGui::Selectable(spell_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }
@@ -310,10 +306,6 @@ void dnd::GUIApp::render_search_window() {
     }
     ImGui::Text("=== ITEMS =========================");
     for (const auto item_ptr : search_result.items) {
-        if (item_ptr->name.empty()) {
-            ImGui::Text("empty item %s", std::to_string(reinterpret_cast<std::uintptr_t>(item_ptr)).c_str());
-            continue;
-        }
         if (ImGui::Selectable(item_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }
@@ -321,10 +313,6 @@ void dnd::GUIApp::render_search_window() {
     }
     ImGui::Text("=== FEATURES ======================");
     for (const auto feature_ptr : search_result.features) {
-        if (feature_ptr->name.empty()) {
-            ImGui::Text("empty feature %s", std::to_string(reinterpret_cast<std::uintptr_t>(feature_ptr)).c_str());
-            continue;
-        }
         if (ImGui::Selectable(feature_ptr->name.c_str(), false)) {
             selected_search_results[i] = true;
         }

--- a/src/gui_app/gui_app.hpp
+++ b/src/gui_app/gui_app.hpp
@@ -22,7 +22,7 @@ namespace dnd {
 struct SearchResult {
     std::vector<const dnd::Spell*> spells;
     std::vector<const dnd::Item*> items;
-    std::vector<const dnd::Feature**> features;
+    std::vector<const dnd::Feature*> features;
 };
 
 /**

--- a/src/gui_app/gui_launcher.cpp
+++ b/src/gui_app/gui_launcher.cpp
@@ -58,7 +58,7 @@ void setup_font() {
     ImGuiIO& io = ImGui::GetIO();
     io.Fonts->AddFontDefault();
     std::filesystem::path aileron_regular_path = std::filesystem::path(DND_ASSET_DIRECTORY) / "Aileron-Regular.ttf";
-    ImFont* main_font = io.Fonts->AddFontFromFileTTF(aileron_regular_path.c_str(), 24.0f);
+    ImFont* main_font = io.Fonts->AddFontFromFileTTF(aileron_regular_path.string().c_str(), 24.0f);
     IM_ASSERT(main_font != nullptr);
     io.FontDefault = main_font;
 }

--- a/tests/parsing/models/character_file_parser_test.cpp
+++ b/tests/parsing/models/character_file_parser_test.cpp
@@ -65,23 +65,21 @@ private:
 
 inline void SetupCharacterParserTest::setClasses() {
     character_classes.create(
-        "Barbarian", "Barbarian", std::vector<dnd::Feature>(), dnd::diceFromInt(12),
+        "Barbarian", "dummy_path", std::vector<dnd::Feature>(), dnd::diceFromInt(12),
         std::vector<int>({4, 8, 12, 16, 19}), 3
     );
 }
 
 inline void SetupCharacterParserTest::setSubclasses() {
-    character_subclasses.create(
-        "Path of the Berserker", "Path of the Berserker", std::vector<dnd::Feature>(), "Barbarian"
-    );
+    character_subclasses.create("Path of the Berserker", "dummy_path", std::vector<dnd::Feature>(), "Barbarian");
 }
 
 inline void SetupCharacterParserTest::setRaces() {
-    character_races.create("Dwarf", "Dwarf", std::vector<dnd::Feature>(), true);
+    character_races.create("Dwarf", "dummy_path", std::vector<dnd::Feature>(), true);
 }
 
 inline void SetupCharacterParserTest::setSubraces() {
-    character_subraces.create("Hill Dwarf", "Hill Dwarf", std::vector<dnd::Feature>(), "Dwarf");
+    character_subraces.create("Hill Dwarf", "dummy_path", std::vector<dnd::Feature>(), "Dwarf");
 }
 
 inline void SetupCharacterParserTest::setSpells() {}


### PR DESCRIPTION
This ambitious restructuring of the ContentLibrary involved a lot of template shenanigans.
I deemed it safer to test it on an extra branch.

Now the ContentLibrary class is written in a way that can either store objects directly or just store pointers to objects elsewhere while handling the search and retrieval of them the same. And unlike before, all of this works without the need for pointers to pointers.
Admitttedly, this makes the code a bit harder to read.
Thus, short hands StoringContentLibrary and ReferencingContentLibrary should now be used to differentiate between the two supported types of content libraries and to keep the code understandable.