### PR TITLE
Effects to stat changes

### DIFF
--- a/src/core/models/character/decision/decision.cpp
+++ b/src/core/models/character/decision/decision.cpp
@@ -27,7 +27,7 @@ dnd::Decision dnd::Decision::create(dnd::DecisionData&& data, const dnd::Content
         throw dnd::invalid_data("Decision data is incompatible with the given content.");
     }
     EffectsData res_data(data.get_character_data());
-    for (const auto& stat_change_str : data.selections["effects"]) {
+    for (const auto& stat_change_str : data.selections["stat_changes"]) {
         StatChangeData stat_change_data(data.get_character_data());
         stat_change_data.stat_change_str = stat_change_str;
         res_data.stat_changes_data.emplace_back(std::move(stat_change_data));

--- a/src/core/models/effects/choice/choice.cpp
+++ b/src/core/models/effects/choice/choice.cpp
@@ -117,14 +117,14 @@ dnd::Choice dnd::Choice::create(dnd::ChoiceData&& data, const dnd::Content& cont
 
     ChoiceType type = choice_type_for_attribute_name(data.attribute_name);
     std::vector<std::unique_ptr<ContentFilter>> filters;
-    switch (type) {
+    switch (type) { // TODO: complete this switch
         case ChoiceType::ABILITY:
             break;
         case ChoiceType::SKILL:
             break;
         case ChoiceType::STRING:
             break;
-        case ChoiceType::EFFECT:
+        case ChoiceType::STAT_CHANGE:
             break;
         case ChoiceType::ITEM:
             break;
@@ -167,7 +167,7 @@ std::set<std::string> dnd::Choice::possible_values(const dnd::Content& content) 
                 }
             };
             [[fallthrough]];
-        case ChoiceType::EFFECT:
+        case ChoiceType::STAT_CHANGE:
             for (const auto& explicit_choice : explicit_choices) {
                 possible_values.emplace(explicit_choice);
             };

--- a/src/core/models/effects/choice/choice_rules.cpp
+++ b/src/core/models/effects/choice/choice_rules.cpp
@@ -9,7 +9,7 @@
 #include <utility>
 
 static constexpr std::array<std::pair<std::string_view, dnd::ChoiceType>, 22> valid_attribute_names = {
-    std::pair("effects", dnd::ChoiceType::EFFECT),
+    std::pair("stat_changes", dnd::ChoiceType::STAT_CHANGE),
     std::pair("cantrips_free", dnd::ChoiceType::SPELL),
     std::pair("spells_at_will", dnd::ChoiceType::SPELL),
     std::pair("spells_innate", dnd::ChoiceType::SPELL),

--- a/src/core/models/effects/choice/choice_rules.hpp
+++ b/src/core/models/effects/choice/choice_rules.hpp
@@ -14,7 +14,7 @@ enum class ChoiceType {
     ABILITY,
     SKILL,
     STRING,
-    EFFECT,
+    STAT_CHANGE,
     ITEM,
     SPELL,
     CHOOSABLE,

--- a/src/core/validation/effects/choice/choice_data.cpp
+++ b/src/core/validation/effects/choice/choice_data.cpp
@@ -143,7 +143,7 @@ dnd::Errors dnd::ChoiceData::validate() const {
         case ChoiceType::SKILL:
             errors += validate_skill_choice(*this, parent);
             break;
-        case ChoiceType::EFFECT:
+        case ChoiceType::STAT_CHANGE:
             errors += validate_stat_change_choice(*this, parent);
             break;
         default:

--- a/tests/testcore/validation/effects/choice/choice_data_test.cpp
+++ b/tests/testcore/validation/effects/choice/choice_data_test.cpp
@@ -61,7 +61,7 @@ TEST_CASE("dnd::ChoiceData::validate and ::validate_relations // valid choice da
     }
 
     SECTION("explicit choices") {
-        choice_data.attribute_name = "effects";
+        choice_data.attribute_name = "stat_changes";
         choice_data.explicit_choices = {"CHA normal add 2", "INT normal add 2"};
         choice_data.amount = 1;
         REQUIRE_NOTHROW(errors = choice_data.validate());


### PR DESCRIPTION
This PR fixes a few missing renamings after the effects (`"effects"`) were renamed to stat changes (`"stat_changes"`).