### PR TITLE
Fix stat change validation

### DIFF
--- a/src/core/validation/effects/stat_change/stat_change_data.cpp
+++ b/src/core/validation/effects/stat_change/stat_change_data.cpp
@@ -14,7 +14,7 @@
 
 static constexpr const char*
     stat_change_regex_cstr = "[A-Z][_A-Z0-9]+ (earliest|early|normal|late|latest) ((add|sub|mult|div|set|max|min) "
-                             "([A-Z][_A-Z0-9]+|-?\\d+(\\.[1-9]|\\.\\d[1-9])?)|(set (false|true)))";
+                             "([A-Z][_A-Z0-9]+|-?[1-9]\\d*(\\.[1-9]|\\.\\d[1-9])?)|(set (false|true)))";
 
 dnd::StatChangeData::StatChangeData(const ValidationData* parent) noexcept : ValidationSubdata(parent) {}
 
@@ -23,10 +23,15 @@ dnd::Errors dnd::StatChangeData::validate() const {
     Errors errors;
     static const std::regex stat_change_regex(stat_change_regex_cstr);
     if (!std::regex_match(stat_change_str, stat_change_regex)) {
-        errors.add_validation_error(
-            ValidationErrorCode::INVALID_ATTRIBUTE_VALUE, parent,
-            fmt::format("Invalid stat change \"{}\"", stat_change_str)
-        );
+        std::string msg;
+        if (stat_change_str.empty()) {
+            msg = "Stat change cannot be empty";
+        } else if (stat_change_str.ends_with("0")) {
+            msg = fmt::format("Stat change \"{}\" ends with unnecessary 0", stat_change_str);
+        } else {
+            msg = fmt::format("Invalid stat change \"{}\"", stat_change_str);
+        }
+        errors.add_validation_error(ValidationErrorCode::INVALID_ATTRIBUTE_VALUE, parent, std::move(msg));
     } else if (stat_change_str.ends_with("div 0")) {
         errors.add_validation_error(
             ValidationErrorCode::INVALID_ATTRIBUTE_VALUE, parent,

--- a/tests/testcore/validation/effects/stat_change/stat_change_data_test.cpp
+++ b/tests/testcore/validation/effects/stat_change/stat_change_data_test.cpp
@@ -207,7 +207,11 @@ TEST_CASE("dnd::StatChangeData::validate // invalid effects", tags) {
         REQUIRE_NOTHROW(errors = stat_change_data.validate());
         REQUIRE_FALSE(errors.ok());
 
-        stat_change_data.stat_change_str = "MY_VALUE_5 latest div 0";
+        stat_change_data.stat_change_str = "MY_VALUE_5 latest mult 01";
+        REQUIRE_NOTHROW(errors = stat_change_data.validate());
+        REQUIRE_FALSE(errors.ok());
+
+        stat_change_data.stat_change_str = "MY_VALUE_5 latest add -04.5";
         REQUIRE_NOTHROW(errors = stat_change_data.validate());
         REQUIRE_FALSE(errors.ok());
 
@@ -234,6 +238,20 @@ TEST_CASE("dnd::StatChangeData::validate // invalid effects", tags) {
         REQUIRE_FALSE(errors.ok());
 
         stat_change_data.stat_change_str = "MY_VALUE_5 latest div MY-VALUE_0";
+        REQUIRE_NOTHROW(errors = stat_change_data.validate());
+        REQUIRE_FALSE(errors.ok());
+    }
+
+    SECTION("divide by zero error") {
+        stat_change_data.stat_change_str = "MY_VALUE_1 earliest div 0";
+        REQUIRE_NOTHROW(errors = stat_change_data.validate());
+        REQUIRE_FALSE(errors.ok());
+
+        stat_change_data.stat_change_str = "MY_VALUE_2 early div 0.0";
+        REQUIRE_NOTHROW(errors = stat_change_data.validate());
+        REQUIRE_FALSE(errors.ok());
+
+        stat_change_data.stat_change_str = "MY_VALUE_3 normal div 0.00";
         REQUIRE_NOTHROW(errors = stat_change_data.validate());
         REQUIRE_FALSE(errors.ok());
     }


### PR DESCRIPTION
This PR fixes unwanted behaviour I found with the validation of stat changes.

### Problem
Stat changes with leading zeros like the following passed validation.
```
DEX normal add 02
STR late mult +04
MY_VALUE normal mult -0014
```
Leading zeros are worse than trailing zeros.
But we accepted leading zeros and rejected trailing zeros without any explanation.

### Fix
This PR changes the validation such that leading zeros are also rejected and adds a custom error message for trailing zeros and empty stat changes, hopefully reducing confusion in the future.