### PR TITLE
Retrieving with optional of reference wrapper

### DIFF
--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -223,7 +223,7 @@ void dnd::CliApp::list_all_content_of_a_type() {
                 break;
             case 7:
                 for (const auto& [_, feature] : session.get_content().get_features().get_all()) {
-                    feature->accept_visitor(visitor);
+                    feature.get().accept_visitor(visitor);
                 }
                 break;
             case 8:
@@ -257,31 +257,31 @@ void dnd::CliApp::list_all_content_of_a_type() {
         }
         switch (type) {
             case 0:
-                display_content_piece(&session.get_content().get_characters().get(index));
+                display_content_piece(&session.get_content().get_characters().get(index).value().get());
                 break;
             case 1:
-                display_content_piece(&session.get_content().get_character_classes().get(index));
+                display_content_piece(&session.get_content().get_character_classes().get(index).value().get());
                 break;
             case 2:
-                display_content_piece(&session.get_content().get_character_subclasses().get(index));
+                display_content_piece(&session.get_content().get_character_subclasses().get(index).value().get());
                 break;
             case 3:
-                display_content_piece(&session.get_content().get_character_races().get(index));
+                display_content_piece(&session.get_content().get_character_races().get(index).value().get());
                 break;
             case 4:
-                display_content_piece(&session.get_content().get_character_subraces().get(index));
+                display_content_piece(&session.get_content().get_character_subraces().get(index).value().get());
                 break;
             case 5:
-                display_content_piece(&session.get_content().get_spells().get(index));
+                display_content_piece(&session.get_content().get_spells().get(index).value().get());
                 break;
             case 6:
-                display_content_piece(&session.get_content().get_items().get(index));
+                display_content_piece(&session.get_content().get_items().get(index).value().get());
                 break;
             case 7:
-                display_content_piece(&session.get_content().get_features().get(index));
+                display_content_piece(&session.get_content().get_features().get(index).value().get());
                 break;
             case 8:
-                display_content_piece(&session.get_content().get_choosables().get(index));
+                display_content_piece(&session.get_content().get_choosables().get(index).value().get());
                 break;
             default:
                 output.error("Invalid type.");

--- a/src/core/content.cpp
+++ b/src/core/content.cpp
@@ -54,7 +54,42 @@ const dnd::StorageContentLibrary<dnd::Spell>& dnd::Content::get_spells() const {
 
 const dnd::ReferencingContentLibrary<dnd::Feature>& dnd::Content::get_features() const { return features; }
 
+const dnd::ReferencingContentLibrary<dnd::ClassFeature>& dnd::Content::get_class_features() const {
+    return class_features;
+}
+
 const dnd::StorageContentLibrary<dnd::Choosable>& dnd::Content::get_choosables() const { return choosables; }
+
+std::optional<dnd::EffectsProviderType> dnd::Content::contains_effects_provider(const std::string& name) const {
+    if (features.contains(name)) {
+        return EffectsProviderType::Feature;
+    }
+    if (class_features.contains(name)) {
+        return EffectsProviderType::ClassFeature;
+    }
+    if (choosables.contains(name)) {
+        return EffectsProviderType::Choosable;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::reference_wrapper<const dnd::EffectsProvider>> dnd::Content::get_effects_provider(
+    const std::string& name
+) const {
+    std::optional<std::reference_wrapper<const Feature>> feature = features.get(name);
+    if (feature.has_value()) {
+        return feature.value();
+    }
+    std::optional<std::reference_wrapper<const ClassFeature>> class_feature = class_features.get(name);
+    if (class_feature.has_value()) {
+        return class_feature.value();
+    }
+    std::optional<std::reference_wrapper<const Choosable>> choosable = choosables.get(name);
+    if (choosable.has_value()) {
+        return choosable.value();
+    }
+    return std::nullopt;
+}
 
 void dnd::Content::set_subgroup(const std::string& group_name, const std::string& subgroup_name) {
     groups.set_subgroup(group_name, subgroup_name);

--- a/src/core/content.cpp
+++ b/src/core/content.cpp
@@ -2,6 +2,8 @@
 
 #include "content.hpp"
 
+#include <functional>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -70,71 +72,83 @@ void dnd::Content::add_group_members(const std::string& group_name, std::set<std
     groups.add(group_name, std::move(values));
 }
 
-bool dnd::Content::add_character(dnd::Character&& character) {
+std::optional<std::reference_wrapper<const dnd::Character>> dnd::Content::add_character(dnd::Character&& character) {
     const std::string name = character.get_name();
-    if (characters.add(std::move(character))) {
-        for (const auto& feature : characters.get(name).get_features()) {
+    auto inserted_character = characters.add(std::move(character));
+    if (inserted_character.has_value()) {
+        for (const auto& feature : inserted_character.value().get().get_features()) {
             features.add(feature);
         }
-        return true;
     }
-    return false;
+    return inserted_character;
 }
 
-bool dnd::Content::add_character_class(dnd::CharacterClass&& character_class) {
+std::optional<std::reference_wrapper<const dnd::CharacterClass>> dnd::Content::add_character_class(
+    dnd::CharacterClass&& character_class
+) {
     const std::string name = character_class.get_name();
-    if (character_classes.add(std::move(character_class))) {
-        for (const auto& feature : character_classes.get(name).get_features()) {
-            features.add(feature);
+    auto inserted_class = character_classes.add(std::move(character_class));
+    if (inserted_class.has_value()) {
+        for (const auto& feature : inserted_class.value().get().get_features()) {
+            class_features.add(feature);
         }
-        return true;
     }
-    return false;
+    return inserted_class;
 }
 
-bool dnd::Content::add_character_subclass(dnd::CharacterSubclass&& character_subclass) {
+std::optional<std::reference_wrapper<const dnd::CharacterSubclass>> dnd::Content::add_character_subclass(
+    dnd::CharacterSubclass&& character_subclass
+) {
     const std::string name = character_subclass.get_name();
+    auto inserted_subclass = character_subclasses.add(std::move(character_subclass));
     if (character_subclasses.add(std::move(character_subclass))) {
-        for (const auto& feature : character_subclasses.get(name).get_features()) {
-            features.add(feature);
+        for (const auto& feature : inserted_subclass.value().get().get_features()) {
+            class_features.add(feature);
         }
-        return true;
     }
-    return false;
+    return inserted_subclass;
 }
 
-bool dnd::Content::add_character_race(dnd::CharacterRace&& character_race) {
+std::optional<std::reference_wrapper<const dnd::CharacterRace>> dnd::Content::add_character_race(
+    dnd::CharacterRace&& character_race
+) {
     const std::string name = character_race.get_name();
-    if (character_races.add(std::move(character_race))) {
-        for (const auto& feature : character_races.get(name).get_features()) {
+    auto inserted_race = character_races.add(std::move(character_race));
+    if (inserted_race.has_value()) {
+        for (const auto& feature : inserted_race.value().get().get_features()) {
             features.add(feature);
         }
-        return true;
     }
-    return false;
+    return inserted_race;
 }
 
-bool dnd::Content::add_character_subrace(dnd::CharacterSubrace&& character_subrace) {
+std::optional<std::reference_wrapper<const dnd::CharacterSubrace>> dnd::Content::add_character_subrace(
+    dnd::CharacterSubrace&& character_subrace
+) {
     const std::string name = character_subrace.get_name();
-    if (character_subraces.add(std::move(character_subrace))) {
-        for (const auto& feature : character_subraces.get(name).get_features()) {
+    auto inserted_subrace = character_subraces.add(std::move(character_subrace));
+    if (inserted_subrace.has_value()) {
+        for (const auto& feature : inserted_subrace.value().get().get_features()) {
             features.add(feature);
         }
-        return true;
     }
-    return false;
+    return inserted_subrace;
 }
 
-bool dnd::Content::add_item(dnd::Item&& item) { return items.add(std::move(item)); }
+std::optional<std::reference_wrapper<const dnd::Item>> dnd::Content::add_item(dnd::Item&& item) {
+    return items.add(std::move(item));
+}
 
-bool dnd::Content::add_spell(dnd::Spell&& spell) { return spells.add(std::move(spell)); }
+std::optional<std::reference_wrapper<const dnd::Spell>> dnd::Content::add_spell(dnd::Spell&& spell) {
+    return spells.add(std::move(spell));
+}
 
-bool dnd::Content::add_choosable(dnd::Choosable&& choosable) {
+std::optional<std::reference_wrapper<const dnd::Choosable>> dnd::Content::add_choosable(dnd::Choosable&& choosable) {
     const std::string name = choosable.get_name();
     const std::string type_name = choosable.get_type();
-    if (choosables.add(std::move(choosable))) {
+    auto inserted_choosable = choosables.add(std::move(choosable));
+    if (inserted_choosable.has_value()) {
         groups.add(type_name, name);
-        return true;
     }
-    return false;
+    return inserted_choosable;
 }

--- a/src/core/content.hpp
+++ b/src/core/content.hpp
@@ -3,6 +3,8 @@
 
 #include <dnd_config.hpp>
 
+#include <functional>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -20,6 +22,12 @@
 #include <core/storage_content_library.hpp>
 
 namespace dnd {
+
+enum class EffectsProviderType {
+    Feature,
+    ClassFeature,
+    Choosable,
+};
 
 /**
  * @brief A class that holds all the content for a certain session or campaign
@@ -49,14 +57,18 @@ public:
     void add_group_member(const std::string& group_name, const std::string& value);
     void add_group_members(const std::string& group_name, std::set<std::string>&& values);
 
-    bool add_character(Character&& character);
-    bool add_character_class(CharacterClass&& character_class);
-    bool add_character_subclass(CharacterSubclass&& character_subclass);
-    bool add_character_race(CharacterRace&& character_race);
-    bool add_character_subrace(CharacterSubrace&& character_subrace);
-    bool add_item(Item&& item);
-    bool add_spell(Spell&& spell);
-    bool add_choosable(Choosable&& choosable);
+    std::optional<std::reference_wrapper<const Character>> add_character(Character&& character);
+    std::optional<std::reference_wrapper<const CharacterClass>> add_character_class(CharacterClass&& character_class);
+    std::optional<std::reference_wrapper<const CharacterSubclass>> add_character_subclass(
+        CharacterSubclass&& character_subclass
+    );
+    std::optional<std::reference_wrapper<const CharacterRace>> add_character_race(CharacterRace&& character_race);
+    std::optional<std::reference_wrapper<const CharacterSubrace>> add_character_subrace(
+        CharacterSubrace&& character_subrace
+    );
+    std::optional<std::reference_wrapper<const Item>> add_item(Item&& item);
+    std::optional<std::reference_wrapper<const Spell>> add_spell(Spell&& spell);
+    std::optional<std::reference_wrapper<const Choosable>> add_choosable(Choosable&& choosable);
 private:
     Groups groups;
     StorageContentLibrary<Character> characters;
@@ -68,6 +80,7 @@ private:
     StorageContentLibrary<Spell> spells;
 
     ReferencingContentLibrary<Feature> features;
+    ReferencingContentLibrary<ClassFeature> class_features;
     StorageContentLibrary<Choosable> choosables;
 };
 

--- a/src/core/content.hpp
+++ b/src/core/content.hpp
@@ -50,7 +50,11 @@ public:
     const StorageContentLibrary<Item>& get_items() const;
     const StorageContentLibrary<Spell>& get_spells() const;
     const ReferencingContentLibrary<Feature>& get_features() const;
+    const ReferencingContentLibrary<ClassFeature>& get_class_features() const;
     const StorageContentLibrary<Choosable>& get_choosables() const;
+
+    std::optional<EffectsProviderType> contains_effects_provider(const std::string& name) const;
+    std::optional<std::reference_wrapper<const EffectsProvider>> get_effects_provider(const std::string& name) const;
 
     void set_subgroup(const std::string& group_name, const std::string& subgroup_name);
     void set_subgroups(const std::string& group_name, std::set<std::string>&& subgroups);

--- a/src/core/content_library.hpp
+++ b/src/core/content_library.hpp
@@ -3,6 +3,7 @@
 
 #include <dnd_config.hpp>
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,17 +26,15 @@ public:
     /**
      * @brief Get content piece by its index
      * @param index the index of the piece of content
-     * @return constant reference to the piece of content if it exists
-     * @throws std::out_of_range if the piece of content does not exist
+     * @return constant reference to the piece of content if it exists, std::nullopt otherwise
      */
-    virtual const T& get(size_t index) const = 0;
+    virtual std::optional<std::reference_wrapper<const T>> get(size_t index) const = 0;
     /**
      * @brief Get content piece by its name
      * @param name the name of the piece of content
-     * @return constant reference to the piece of content if it exists
-     * @throws std::out_of_range if the piece of content does not exist
+     * @return constant reference to the piece of content if it exists, std::nullopt otherwise
      */
-    virtual const T& get(const std::string& name) const = 0;
+    virtual std::optional<std::reference_wrapper<const T>> get(const std::string& name) const = 0;
     /**
      * @brief Get the root of the fuzzy search trie
      * @return a pointer to the root of the fuzzy search trie

--- a/src/core/models/character/character_basis.cpp
+++ b/src/core/models/character/character_basis.cpp
@@ -19,15 +19,15 @@ dnd::CharacterBasis dnd::CharacterBasis::create(dnd::CharacterBasisData&& data, 
     if (!data.validate_relations(content).ok()) {
         throw dnd::invalid_data("CharacterBasis data is incompatible with the given content.");
     }
-    const CharacterRace* race = &content.get_character_races().get(data.race_name);
+    const CharacterRace* race = &content.get_character_races().get(data.race_name).value().get();
     const CharacterSubrace* subrace = nullptr;
-    const CharacterClass* cls = &content.get_character_classes().get(data.class_name);
+    const CharacterClass* cls = &content.get_character_classes().get(data.class_name).value().get();
     const CharacterSubclass* subclass = nullptr;
     if (!data.subrace_name.empty()) {
-        subrace = &content.get_character_subraces().get(data.subrace_name);
+        subrace = &content.get_character_subraces().get(data.subrace_name).value().get();
     }
     if (!data.subclass_name.empty()) {
-        subclass = &content.get_character_subclasses().get(data.subclass_name);
+        subclass = &content.get_character_subclasses().get(data.subclass_name).value().get();
     }
     return CharacterBasis(race, subrace, cls, subclass);
 }

--- a/src/core/models/character_subclass/character_subclass.cpp
+++ b/src/core/models/character_subclass/character_subclass.cpp
@@ -30,7 +30,7 @@ dnd::CharacterSubclass dnd::CharacterSubclass::create(dnd::CharacterSubclassData
     for (auto& feature_data : data.features_data) {
         features.emplace_back(ClassFeature::create(std::move(feature_data), content));
     }
-    const CharacterClass* cls = &content.get_character_classes().get(data.class_name);
+    const CharacterClass* cls = &content.get_character_classes().get(data.class_name).value().get();
     return CharacterSubclass(
         std::move(data.name), std::move(data.description), std::move(data.source_path), std::move(features), cls,
         create_spellcasting(std::move(data.spellcasting_data))

--- a/src/core/models/character_subrace/character_subrace.cpp
+++ b/src/core/models/character_subrace/character_subrace.cpp
@@ -28,7 +28,7 @@ dnd::CharacterSubrace dnd::CharacterSubrace::create(dnd::CharacterSubraceData&& 
     for (auto& feature_data : data.features_data) {
         features.emplace_back(Feature::create(std::move(feature_data), content));
     }
-    const CharacterRace* race = &content.get_character_races().get(data.race_name);
+    const CharacterRace* race = &content.get_character_races().get(data.race_name).value().get();
     return CharacterSubrace(
         std::move(data.name), std::move(data.description), std::move(data.source_path), std::move(features), race
     );

--- a/src/core/models/effects/subholders/extra_spells_holder.cpp
+++ b/src/core/models/effects/subholders/extra_spells_holder.cpp
@@ -17,7 +17,7 @@ static std::vector<const dnd::Spell*> find_spells_in_content(
     std::vector<const dnd::Spell*> spells;
     spells.reserve(spell_names.size());
     for (const auto& spell_name : spell_names) {
-        spells.push_back(&content.get_spells().get(spell_name));
+        spells.push_back(&content.get_spells().get(spell_name).value().get());
     }
     return spells;
 }

--- a/src/core/referencing_content_library.hpp
+++ b/src/core/referencing_content_library.hpp
@@ -30,7 +30,7 @@ public:
     size_t size() const override;
     std::optional<std::reference_wrapper<const T>> get(size_t index) const override;
     std::optional<std::reference_wrapper<const T>> get(const std::string& name) const override;
-    const std::unordered_map<std::string, const T*>& get_all() const;
+    const std::unordered_map<std::string, std::reference_wrapper<const T>>& get_all() const;
     /**
      * @brief Add a content piece to a content piece to the library
      * @param content_piece the content piece to add
@@ -107,7 +107,7 @@ std::optional<std::reference_wrapper<const T>> ReferencingContentLibrary<T>::get
 
 template <typename T>
 requires isContentPieceType<T>
-const std::unordered_map<std::string, const T*>& ReferencingContentLibrary<T>::get_all() const {
+const std::unordered_map<std::string, std::reference_wrapper<const T>>& ReferencingContentLibrary<T>::get_all() const {
     return data;
 }
 

--- a/src/core/searching/content_filters/content_piece_filter.cpp
+++ b/src/core/searching/content_filters/content_piece_filter.cpp
@@ -65,8 +65,13 @@ std::vector<const dnd::ContentPiece*> dnd::ContentPieceFilter::all_matches(const
         }
     }
     for (const auto& [_, feature] : content.get_features().get_all()) {
-        if (matches(*feature)) {
-            matching_content_pieces.emplace_back(feature);
+        if (matches(feature)) {
+            matching_content_pieces.emplace_back(&feature.get());
+        }
+    }
+    for (const auto& [_, class_feature] : content.get_class_features().get_all()) {
+        if (matches(class_feature)) {
+            matching_content_pieces.emplace_back(&class_feature.get());
         }
     }
     for (const auto& [_, choosable] : content.get_choosables().get_all()) {

--- a/src/core/searching/content_filters/effects_provider/feature_filter.cpp
+++ b/src/core/searching/content_filters/effects_provider/feature_filter.cpp
@@ -16,8 +16,8 @@ bool dnd::FeatureFilter::matches(const Feature& feature) const noexcept { return
 std::vector<const dnd::ContentPiece*> dnd::FeatureFilter::all_matches(const Content& content) const {
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, feature] : content.get_features().get_all()) {
-        if (matches(*feature)) {
-            matching_content_pieces.emplace_back(feature);
+        if (matches(feature)) {
+            matching_content_pieces.emplace_back(&feature.get());
         }
     }
     return matching_content_pieces;

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -360,48 +360,57 @@ void dnd::Session::parse_content_and_initialize() {
 
 void dnd::Session::open_last_session() {
     for (const std::string& character_to_open : last_session_open_tabs["characters"]) {
-        if (content.get_characters().contains(character_to_open)) {
-            open_content_pieces.push_back(&content.get_characters().get(character_to_open));
+        auto character = content.get_characters().get(character_to_open);
+        if (character.has_value()) {
+            open_content_pieces.push_back(&character.value().get());
         }
     }
     for (const std::string& character_class_to_open : last_session_open_tabs["character_classes"]) {
-        if (content.get_character_classes().contains(character_class_to_open)) {
-            open_content_pieces.push_back(&content.get_character_classes().get(character_class_to_open));
+        auto character_class = content.get_character_classes().get(character_class_to_open);
+        if (character_class.has_value()) {
+            open_content_pieces.push_back(&character_class.value().get());
         }
     }
     for (const std::string& character_subclass_to_open : last_session_open_tabs["character_subclasses"]) {
-        if (content.get_character_subclasses().contains(character_subclass_to_open)) {
-            open_content_pieces.push_back(&content.get_character_subclasses().get(character_subclass_to_open));
+        auto character_subclass = content.get_character_subclasses().get(character_subclass_to_open);
+        if (character_subclass.has_value()) {
+            open_content_pieces.push_back(&character_subclass.value().get());
         }
     }
     for (const std::string& character_race_to_open : last_session_open_tabs["character_races"]) {
-        if (content.get_character_races().contains(character_race_to_open)) {
-            open_content_pieces.push_back(&content.get_character_races().get(character_race_to_open));
+        auto character_race = content.get_character_races().get(character_race_to_open);
+        if (character_race.has_value()) {
+            open_content_pieces.push_back(&character_race.value().get());
         }
     }
     for (const std::string& character_subrace_to_open : last_session_open_tabs["character_subraces"]) {
-        if (content.get_character_subraces().contains(character_subrace_to_open)) {
-            open_content_pieces.push_back(&content.get_character_subraces().get(character_subrace_to_open));
+        auto character_subrace = content.get_character_subraces().get(character_subrace_to_open);
+        if (character_subrace.has_value()) {
+            open_content_pieces.push_back(&character_subrace.value().get());
         }
     }
     for (const std::string& item_to_open : last_session_open_tabs["items"]) {
-        if (content.get_items().contains(item_to_open)) {
-            open_content_pieces.push_back(&content.get_items().get(item_to_open));
+        auto item = content.get_items().get(item_to_open);
+        if (item.has_value()) {
+            open_content_pieces.push_back(&item.value().get());
         }
     }
     for (const std::string& spell_to_open : last_session_open_tabs["spells"]) {
-        if (content.get_spells().contains(spell_to_open)) {
-            open_content_pieces.push_back(&content.get_spells().get(spell_to_open));
+        auto spell = content.get_spells().get(spell_to_open);
+        if (spell.has_value()) {
+            open_content_pieces.push_back(&spell.value().get());
         }
     }
     for (const std::string& feature_to_open : last_session_open_tabs["features"]) {
-        if (content.get_features().contains(feature_to_open)) {
-            open_content_pieces.push_back(&content.get_features().get(feature_to_open));
+        auto feature = content.get_features().get(feature_to_open);
+        if (feature.has_value()) {
+            open_content_pieces.push_back(&feature.value().get());
         }
     }
     for (const std::string& choosable_to_open : last_session_open_tabs["choosables"]) {
-        if (content.get_choosables().contains(choosable_to_open)) {
-            open_content_pieces.push_back(&content.get_choosables().get(choosable_to_open));
+        auto choosable = content.get_choosables().get(choosable_to_open);
+        if (choosable.has_value()) {
+            open_content_pieces.push_back(&choosable.value().get());
         }
     }
 }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -407,6 +407,12 @@ void dnd::Session::open_last_session() {
             open_content_pieces.push_back(&feature.value().get());
         }
     }
+    for (const std::string& class_feature_to_open : last_session_open_tabs["class_features"]) {
+        auto class_feature = content.get_class_features().get(class_feature_to_open);
+        if (class_feature.has_value()) {
+            open_content_pieces.push_back(&class_feature.value().get());
+        }
+    }
     for (const std::string& choosable_to_open : last_session_open_tabs["choosables"]) {
         auto choosable = content.get_choosables().get(choosable_to_open);
         if (choosable.has_value()) {

--- a/src/core/validation/character/character_basis_data.cpp
+++ b/src/core/validation/character/character_basis_data.cpp
@@ -29,12 +29,14 @@ dnd::Errors dnd::CharacterBasisData::validate() const {
 
 dnd::Errors dnd::CharacterBasisData::validate_relations(const dnd::Content& content) const {
     Errors errors;
-    if (!content.get_character_races().contains(race_name)) {
+    auto race_optional = content.get_character_races().get(race_name);
+    if (!race_optional.has_value()) {
         errors.add_validation_error(
             ValidationErrorCode::RELATION_NOT_FOUND, parent, fmt::format("Race '{}' does not exist.", race_name)
         );
     } else if (!subrace_name.empty()) {
-        if (!content.get_character_races().get(race_name).has_subraces()) {
+        const CharacterRace& race = race_optional.value();
+        if (!race.has_subraces()) {
             errors.add_validation_error(
                 ValidationErrorCode::INVALID_RELATION, parent,
                 fmt::format("Race '{}' does not have subraces.", race_name)
@@ -46,7 +48,7 @@ dnd::Errors dnd::CharacterBasisData::validate_relations(const dnd::Content& cont
                 fmt::format("Subrace '{}' does not exist.", subrace_name)
             );
         }
-    } else if (content.get_character_races().get(race_name).has_subraces()) {
+    } else if (race_optional.value().get().has_subraces()) {
         errors.add_validation_error(
             ValidationErrorCode::INVALID_RELATION, parent, fmt::format("Race '{}' requires subraces.", race_name)
         );

--- a/src/core/validation/character/decision/decision_data.cpp
+++ b/src/core/validation/character/decision/decision_data.cpp
@@ -109,7 +109,7 @@ dnd::Errors dnd::DecisionData::validate_relations(const dnd::Content& content) c
         return errors;
     }
 
-    const Feature& linked_feature = content.get_features().get(feature_name);
+    const Feature& linked_feature = content.get_features().get(feature_name).value().get();
     std::vector<const Effects*> effects_with_choices = linked_feature.get_all_effects();
 
     bool target_found_in_feature = false;
@@ -128,26 +128,28 @@ dnd::Errors dnd::DecisionData::validate_relations(const dnd::Content& content) c
     bool feature_found = false;
     if (character_data != nullptr) {
         const std::string& race_name = character_data->character_basis_data.race_name;
-        if (content.get_character_races().contains(race_name)) {
-            feature_found = feature_is_in(linked_feature, content.get_character_races().get(race_name).get_features());
+        auto race_optional = content.get_character_races().get(race_name);
+        if (race_optional.has_value()) {
+            const CharacterRace& race = race_optional.value();
+            feature_found = feature_is_in(linked_feature, race.get_features());
         }
         const std::string& subrace_name = character_data->character_basis_data.subrace_name;
-        if (!feature_found && content.get_character_subraces().contains(subrace_name)) {
-            feature_found = feature_is_in(
-                linked_feature, content.get_character_subraces().get(subrace_name).get_features()
-            );
+        auto subrace_optional = content.get_character_subraces().get(subrace_name);
+        if (!feature_found && subrace_optional.has_value()) {
+            const CharacterSubrace& subrace = subrace_optional.value();
+            feature_found = feature_is_in(linked_feature, subrace.get_features());
         }
         const std::string& class_name = character_data->character_basis_data.class_name;
-        if (!feature_found && content.get_character_classes().contains(class_name)) {
-            feature_found = class_feature_is_in(
-                linked_feature, content.get_character_classes().get(class_name).get_features()
-            );
+        auto class_optional = content.get_character_classes().get(class_name);
+        if (!feature_found && class_optional.has_value()) {
+            const CharacterClass& cls = class_optional.value();
+            feature_found = class_feature_is_in(linked_feature, cls.get_features());
         }
         const std::string& subclass_name = character_data->character_basis_data.subclass_name;
+        auto subclass_optional = content.get_character_subclasses().get(subclass_name);
         if (!feature_found && content.get_character_subclasses().contains(subclass_name)) {
-            feature_found = class_feature_is_in(
-                linked_feature, content.get_character_subclasses().get(subclass_name).get_features()
-            );
+            const CharacterSubclass& subclass = subclass_optional.value();
+            feature_found = class_feature_is_in(linked_feature, subclass.get_features());
         }
     }
     if (!feature_found) {

--- a/src/core/validation/character_class/character_class_data.cpp
+++ b/src/core/validation/character_class/character_class_data.cpp
@@ -73,7 +73,7 @@ dnd::Errors dnd::CharacterClassData::validate_relations(const dnd::Content& cont
     }
     for (const auto& feature_data : features_data) {
         errors += feature_data.validate_relations(content);
-        if (content.get_features().contains(feature_data.name)) {
+        if (content.get_class_features().contains(feature_data.name)) {
             errors.add_validation_error(
                 ValidationErrorCode::INVALID_ATTRIBUTE_VALUE, this,
                 fmt::format("Feature has duplicate name \"{}\".", feature_data.name)

--- a/src/core/validation/character_subclass/character_subclass_data.cpp
+++ b/src/core/validation/character_subclass/character_subclass_data.cpp
@@ -60,19 +60,20 @@ dnd::Errors dnd::CharacterSubclassData::validate_relations(const Content& conten
     }
     for (const auto& feature_data : features_data) {
         errors += feature_data.validate_relations(content);
-        if (content.get_features().contains(feature_data.name)) {
+        if (content.get_class_features().contains(feature_data.name)) {
             errors.add_validation_error(
                 ValidationErrorCode::INVALID_ATTRIBUTE_VALUE, this,
                 fmt::format("Feature has duplicate name \"{}\".", feature_data.name)
             );
         }
     }
-    if (!content.get_character_classes().contains(class_name)) {
+    auto class_optional = content.get_character_classes().get(class_name);
+    if (!class_optional.has_value()) {
         errors.add_validation_error(
             ValidationErrorCode::RELATION_NOT_FOUND, this,
             fmt::format("Character class '{}' does not exist.", class_name)
         );
-    } else if (spellcasting_data.is_spellcaster && content.get_character_classes().get(class_name).has_spellcasting()) {
+    } else if (spellcasting_data.is_spellcaster && class_optional.value().get().has_spellcasting()) {
         errors.add_validation_error(
             ValidationErrorCode::INVALID_RELATION, this,
             fmt::format(

--- a/src/core/validation/character_subrace/character_subrace_data.cpp
+++ b/src/core/validation/character_subrace/character_subrace_data.cpp
@@ -62,11 +62,12 @@ dnd::Errors dnd::CharacterSubraceData::validate_relations(const Content& content
             );
         }
     }
-    if (!content.get_character_races().contains(race_name)) {
+    auto race_optional = content.get_character_races().get(race_name);
+    if (!race_optional.has_value()) {
         errors.add_validation_error(
             ValidationErrorCode::RELATION_NOT_FOUND, this, fmt::format("Character race '{}' does not exist.", race_name)
         );
-    } else if (!content.get_character_races().get(race_name).has_subraces()) {
+    } else if (!race_optional.value().get().has_subraces()) {
         errors.add_validation_error(
             ValidationErrorCode::INVALID_RELATION, this,
             fmt::format("Character race '{}' does not have subraces.", race_name)

--- a/src/core/validation/effects/subholders/extra_spells_holder_data.cpp
+++ b/src/core/validation/effects/subholders/extra_spells_holder_data.cpp
@@ -47,12 +47,13 @@ static dnd::Errors spells_set_validate_relations(
     dnd::Errors errors;
 
     for (const auto& spell_name : spells) {
-        if (!content.get_spells().contains(spell_name)) {
+        auto spell_optional = content.get_spells().get(spell_name);
+        if (!spell_optional.has_value()) {
             errors.add_validation_error(
                 dnd::ValidationErrorCode::RELATION_NOT_FOUND, parent,
                 fmt::format("Spell '{}' does not exist.", spell_name)
             );
-        } else if (content.get_spells().get(spell_name).get_type().get_spell_level() == dnd::SpellLevel::CANTRIP) {
+        } else if (spell_optional.value().get().get_type().get_spell_level() == dnd::SpellLevel::CANTRIP) {
             errors.add_validation_error(
                 dnd::ValidationErrorCode::INVALID_RELATION, parent, fmt::format("Spell '{}' is a cantrip.", spell_name)
             );
@@ -64,12 +65,13 @@ static dnd::Errors spells_set_validate_relations(
 dnd::Errors dnd::ExtraSpellsHolderData::validate_relations(const Content& content) const {
     Errors errors;
     for (const auto& cantrip_name : free_cantrips) {
-        if (!content.get_spells().contains(cantrip_name)) {
+        auto cantrip_optional = content.get_spells().get(cantrip_name);
+        if (!cantrip_optional.has_value()) {
             errors.add_validation_error(
                 dnd::ValidationErrorCode::RELATION_NOT_FOUND, parent,
                 fmt::format("Cantrip '{}' does not exist.", cantrip_name)
             );
-        } else if (content.get_spells().get(cantrip_name).get_type().get_spell_level() != dnd::SpellLevel::CANTRIP) {
+        } else if (cantrip_optional.value().get().get_type().get_spell_level() != dnd::SpellLevel::CANTRIP) {
             errors.add_validation_error(
                 dnd::ValidationErrorCode::INVALID_RELATION, parent,
                 fmt::format("Spell '{}' is not a cantrip.", cantrip_name)

--- a/src/gui/gui_app.cpp
+++ b/src/gui/gui_app.cpp
@@ -73,6 +73,7 @@ static void render_content_count_table(const dnd::Content& content) {
     display_size("Items", content.get_items().size(), w);
     display_size("Spells", content.get_spells().size(), w);
     display_size("Features", content.get_features().size(), w);
+    display_size("Class Features", content.get_class_features().size(), w);
     display_size("Choosables", content.get_choosables().size(), w);
 }
 


### PR DESCRIPTION
This PR merges the feature branch that was intended for the implementation of functions which would provide tools to deal with the different types of effects providers.
While implementing this I starting changing a lot of the content libraries' APIs.
Previously, one would first ask the library if something exists, and then get it, because `get()` would throw if the object wouldn't exist.
```cpp
if (library.contains(item_name)) {
    const auto& item = library.get(item_name);
}
```
With the new approach, using `std::optional` in combination with `std::reference_wrapper`, only one hash has to be evaluated and we still have the security of references.
```cpp
auto item_optional = library.get(item_name);
if (item_optional.has_value()) {
    const auto& item = item_optional.value();
}
```
This approach still has few problems, but I am going to merge it for now and open an issue about addressing these issues.