### PR TITLE
Fix noexcept

### DIFF
--- a/src/core/basic_mechanics/dice.cpp
+++ b/src/core/basic_mechanics/dice.cpp
@@ -88,7 +88,7 @@ static tl::expected<const char*, Errors> dice_type_to_string(DiceType dice_type)
 }
 
 
-tl::expected<Dice, Errors> Dice::single_from_int(int dice_number) noexcept {
+tl::expected<Dice, Errors> Dice::single_from_int(int dice_number) {
     tl::expected<DiceType, Errors> dice_type = int_to_dice_type(dice_number);
     if (dice_type.has_value()) {
         return Dice::from_dice_count_map(std::map<DiceType, int>{{dice_type.value(), 1}});
@@ -97,7 +97,7 @@ tl::expected<Dice, Errors> Dice::single_from_int(int dice_number) noexcept {
     }
 }
 
-tl::expected<Dice, Errors> Dice::single_from_int_with_modifier(int dice_number, int modifier) noexcept {
+tl::expected<Dice, Errors> Dice::single_from_int_with_modifier(int dice_number, int modifier) {
     tl::expected<DiceType, Errors> dice_type = int_to_dice_type(dice_number);
     if (dice_type.has_value()) {
         return Dice::from_dice_count_map_with_modifier(std::map<DiceType, int>{{dice_type.value(), 1}}, modifier);
@@ -106,7 +106,7 @@ tl::expected<Dice, Errors> Dice::single_from_int_with_modifier(int dice_number, 
     }
 }
 
-tl::expected<Dice, Errors> Dice::multi_from_int(int dice_number, int dice_count) noexcept {
+tl::expected<Dice, Errors> Dice::multi_from_int(int dice_number, int dice_count) {
     tl::expected<DiceType, Errors> dice_type = int_to_dice_type(dice_number);
     if (dice_type.has_value()) {
         return Dice::from_dice_count_map(std::map<DiceType, int>{{dice_type.value(), dice_count}});
@@ -115,7 +115,7 @@ tl::expected<Dice, Errors> Dice::multi_from_int(int dice_number, int dice_count)
     }
 }
 
-tl::expected<Dice, Errors> Dice::multi_from_int_with_modifier(int dice_number, int dice_count, int modifier) noexcept {
+tl::expected<Dice, Errors> Dice::multi_from_int_with_modifier(int dice_number, int dice_count, int modifier) {
     tl::expected<DiceType, Errors> dice_type = int_to_dice_type(dice_number);
     if (dice_type.has_value()) {
         return Dice::from_dice_count_map_with_modifier(
@@ -126,11 +126,11 @@ tl::expected<Dice, Errors> Dice::multi_from_int_with_modifier(int dice_number, i
     }
 }
 
-tl::expected<Dice, Errors> Dice::from_string(const std::string& str) noexcept {
+tl::expected<Dice, Errors> Dice::from_string(const std::string& str) {
     return Dice::from_string(std::string(str));
 }
 
-tl::expected<Dice, Errors> Dice::from_string(std::string&& str) noexcept {
+tl::expected<Dice, Errors> Dice::from_string(std::string&& str) {
     string_lowercase_inplace(str);
     std::map<DiceType, int> dice_counts;
     int modifier = 0;
@@ -189,13 +189,13 @@ tl::expected<Dice, Errors> Dice::from_string(std::string&& str) noexcept {
     return Dice::from_dice_count_map_with_modifier(std::move(dice_counts), modifier);
 }
 
-tl::expected<Dice, Errors> Dice::from_dice_count_map(std::map<DiceType, int>&& dice_counts) noexcept {
+tl::expected<Dice, Errors> Dice::from_dice_count_map(std::map<DiceType, int>&& dice_counts) {
     return Dice::from_dice_count_map_with_modifier(std::move(dice_counts), 0);
 }
 
 tl::expected<Dice, Errors> Dice::from_dice_count_map_with_modifier(
     std::map<DiceType, int>&& dice_counts, int modifier
-) noexcept {
+) {
     Errors errors;
     for (const auto& [dice_type, dice_count] : dice_counts) {
         if (dice_count < 0) {
@@ -218,10 +218,10 @@ tl::expected<Dice, Errors> Dice::from_dice_count_map_with_modifier(
     return Dice(std::move(dice_counts), modifier);
 }
 
-Dice::Dice(std::map<DiceType, int>&& dice_counts, int modifier) noexcept
+Dice::Dice(std::map<DiceType, int>&& dice_counts, int modifier)
     : dice_counts(dice_counts), modifier(modifier) {}
 
-int Dice::min_value() const noexcept {
+int Dice::min_value() const {
     int min_value = modifier;
     for (const auto& [dice_type, dice_count] : dice_counts) {
         min_value += dice_count;
@@ -229,7 +229,7 @@ int Dice::min_value() const noexcept {
     return min_value;
 }
 
-int Dice::max_value() const noexcept {
+int Dice::max_value() const {
     int max_value = modifier;
     for (const auto& [dice_type, dice_count] : dice_counts) {
         max_value += static_cast<int>(dice_type) * dice_count;
@@ -237,9 +237,9 @@ int Dice::max_value() const noexcept {
     return max_value;
 }
 
-bool Dice::value_is_possible(int value) const noexcept { return value >= min_value() && value <= max_value(); }
+bool Dice::value_is_possible(int value) const { return value >= min_value() && value <= max_value(); }
 
-std::string Dice::to_string() const noexcept {
+std::string Dice::to_string() const {
     std::string str;
     bool first = true;
     for (const auto& [dice_type, dice_count] : dice_counts) {

--- a/src/core/basic_mechanics/dice.cpp
+++ b/src/core/basic_mechanics/dice.cpp
@@ -126,9 +126,7 @@ tl::expected<Dice, Errors> Dice::multi_from_int_with_modifier(int dice_number, i
     }
 }
 
-tl::expected<Dice, Errors> Dice::from_string(const std::string& str) {
-    return Dice::from_string(std::string(str));
-}
+tl::expected<Dice, Errors> Dice::from_string(const std::string& str) { return Dice::from_string(std::string(str)); }
 
 tl::expected<Dice, Errors> Dice::from_string(std::string&& str) {
     string_lowercase_inplace(str);
@@ -218,8 +216,7 @@ tl::expected<Dice, Errors> Dice::from_dice_count_map_with_modifier(
     return Dice(std::move(dice_counts), modifier);
 }
 
-Dice::Dice(std::map<DiceType, int>&& dice_counts, int modifier)
-    : dice_counts(dice_counts), modifier(modifier) {}
+Dice::Dice(std::map<DiceType, int>&& dice_counts, int modifier) : dice_counts(dice_counts), modifier(modifier) {}
 
 int Dice::min_value() const {
     int min_value = modifier;

--- a/src/core/basic_mechanics/dice.hpp
+++ b/src/core/basic_mechanics/dice.hpp
@@ -27,9 +27,7 @@ public:
     static tl::expected<Dice, Errors> single_from_int(int dice_number);
     static tl::expected<Dice, Errors> single_from_int_with_modifier(int dice_number, int modifier);
     static tl::expected<Dice, Errors> multi_from_int(int dice_number, int dice_count);
-    static tl::expected<Dice, Errors> multi_from_int_with_modifier(
-        int dice_number, int dice_count, int modifier
-    );
+    static tl::expected<Dice, Errors> multi_from_int_with_modifier(int dice_number, int dice_count, int modifier);
     static tl::expected<Dice, Errors> from_string(const std::string& str);
     static tl::expected<Dice, Errors> from_string(std::string&& str);
     static tl::expected<Dice, Errors> from_dice_count_map(std::map<DiceType, int>&& dice_counts);

--- a/src/core/basic_mechanics/dice.hpp
+++ b/src/core/basic_mechanics/dice.hpp
@@ -24,26 +24,26 @@ enum class DiceType {
 
 class Dice {
 public:
-    static tl::expected<Dice, Errors> single_from_int(int dice_number) noexcept;
-    static tl::expected<Dice, Errors> single_from_int_with_modifier(int dice_number, int modifier) noexcept;
-    static tl::expected<Dice, Errors> multi_from_int(int dice_number, int dice_count) noexcept;
+    static tl::expected<Dice, Errors> single_from_int(int dice_number);
+    static tl::expected<Dice, Errors> single_from_int_with_modifier(int dice_number, int modifier);
+    static tl::expected<Dice, Errors> multi_from_int(int dice_number, int dice_count);
     static tl::expected<Dice, Errors> multi_from_int_with_modifier(
         int dice_number, int dice_count, int modifier
-    ) noexcept;
-    static tl::expected<Dice, Errors> from_string(const std::string& str) noexcept;
-    static tl::expected<Dice, Errors> from_string(std::string&& str) noexcept;
-    static tl::expected<Dice, Errors> from_dice_count_map(std::map<DiceType, int>&& dice_counts) noexcept;
+    );
+    static tl::expected<Dice, Errors> from_string(const std::string& str);
+    static tl::expected<Dice, Errors> from_string(std::string&& str);
+    static tl::expected<Dice, Errors> from_dice_count_map(std::map<DiceType, int>&& dice_counts);
     static tl::expected<Dice, Errors> from_dice_count_map_with_modifier(
         std::map<DiceType, int>&& dice_counts, int modifier
-    ) noexcept;
+    );
 
-    int min_value() const noexcept;
-    int max_value() const noexcept;
-    bool value_is_possible(int value) const noexcept;
+    int min_value() const;
+    int max_value() const;
+    bool value_is_possible(int value) const;
 
-    std::string to_string() const noexcept;
+    std::string to_string() const;
 private:
-    Dice(std::map<DiceType, int>&& dice_counts, int modifier) noexcept;
+    Dice(std::map<DiceType, int>&& dice_counts, int modifier);
 
     std::map<DiceType, int> dice_counts;
     int modifier;

--- a/src/core/basic_mechanics/skills.cpp
+++ b/src/core/basic_mechanics/skills.cpp
@@ -23,7 +23,7 @@ static constexpr std::array<std::pair<std::string_view, std::string_view>, 18> s
     std::pair("SLEIGHT_OF_HAND", "DEX"), std::pair("STEALTH", "DEX"),         std::pair("SURVIVAL", "WIS"),
 };
 
-bool is_skill(const std::string& skill) noexcept {
+bool is_skill(const std::string& skill) {
     for (const auto& skill_ability_pair : skill_abilities) {
         std::string_view skill_to_check = skill_ability_pair.first;
         if (skill.size() != skill_to_check.size()) {
@@ -48,7 +48,7 @@ bool is_skill(const std::string& skill) noexcept {
     return false;
 }
 
-std::vector<std::string> get_all_skills() noexcept {
+std::vector<std::string> get_all_skills() {
     std::vector<std::string> skills;
     skills.reserve(skill_abilities.size());
     for (const auto& [skill_name, _] : skill_abilities) {
@@ -63,7 +63,7 @@ std::vector<std::string> get_all_skills() noexcept {
     return skills;
 }
 
-std::map<std::string, std::string> get_abilities_for_all_skills() noexcept {
+std::map<std::string, std::string> get_abilities_for_all_skills() {
     std::map<std::string, std::string> skill_ability_map;
     for (const auto& skill_ability_pair : skill_abilities) {
         skill_ability_map.emplace(skill_ability_pair);

--- a/src/core/basic_mechanics/skills.hpp
+++ b/src/core/basic_mechanics/skills.hpp
@@ -9,11 +9,11 @@
 
 namespace dnd {
 
-bool is_skill(const std::string& skill) noexcept;
+bool is_skill(const std::string& skill);
 
-std::vector<std::string> get_all_skills() noexcept;
+std::vector<std::string> get_all_skills();
 
-std::map<std::string, std::string> get_abilities_for_all_skills() noexcept;
+std::map<std::string, std::string> get_abilities_for_all_skills();
 
 } // namespace dnd
 

--- a/src/core/errors/errors.cpp
+++ b/src/core/errors/errors.cpp
@@ -13,9 +13,9 @@
 
 namespace dnd {
 
-Errors::Errors(Error&& error) noexcept { errors.emplace_back(std::move(error)); }
+Errors::Errors(Error&& error) { errors.emplace_back(std::move(error)); }
 
-bool Errors::ok() const noexcept { return errors.empty(); }
+bool Errors::ok() const { return errors.empty(); }
 
 void Errors::add_parsing_error(
     ParsingError::Code error_code, const std::filesystem::path& filepath, std::string&& message
@@ -37,7 +37,7 @@ void Errors::add_runtime_error(RuntimeError::Code error_code, std::string&& mess
 
 void Errors::add_runtime_error(RuntimeError&& error) { errors.emplace_back(std::move(error)); }
 
-const std::vector<Error>& Errors::get_errors() const noexcept { return errors; }
+const std::vector<Error>& Errors::get_errors() const { return errors; }
 
 void Errors::merge(Errors&& other) {
     errors.insert(

--- a/src/core/errors/errors.cpp
+++ b/src/core/errors/errors.cpp
@@ -13,29 +13,29 @@
 
 namespace dnd {
 
-Errors::Errors(Error&& error) { errors.emplace_back(std::move(error)); }
+Errors::Errors(Error&& error) : errors({std::move(error)}) {}
 
 bool Errors::ok() const { return errors.empty(); }
 
 void Errors::add_parsing_error(
     ParsingError::Code error_code, const std::filesystem::path& filepath, std::string&& message
 ) {
-    errors.emplace_back(ParsingError(error_code, std::move(filepath), std::move(message)));
+    errors.push_back(ParsingError(error_code, std::move(filepath), std::move(message)));
 }
 
-void Errors::add_parsing_error(ParsingError&& error) { errors.emplace_back(std::move(error)); }
+void Errors::add_parsing_error(ParsingError&& error) { errors.push_back(std::move(error)); }
 
 void Errors::add_validation_error(ValidationError::Code error_code, std::string&& message) {
-    errors.emplace_back(ValidationError(error_code, std::move(message)));
+    errors.push_back(ValidationError(error_code, std::move(message)));
 }
 
-void Errors::add_validation_error(ValidationError&& error) { errors.emplace_back(std::move(error)); }
+void Errors::add_validation_error(ValidationError&& error) { errors.push_back(std::move(error)); }
 
 void Errors::add_runtime_error(RuntimeError::Code error_code, std::string&& message) {
-    errors.emplace_back(RuntimeError(error_code, std::move(message)));
+    errors.push_back(RuntimeError(error_code, std::move(message)));
 }
 
-void Errors::add_runtime_error(RuntimeError&& error) { errors.emplace_back(std::move(error)); }
+void Errors::add_runtime_error(RuntimeError&& error) { errors.push_back(std::move(error)); }
 
 const std::vector<Error>& Errors::get_errors() const { return errors; }
 

--- a/src/core/errors/errors.hpp
+++ b/src/core/errors/errors.hpp
@@ -24,8 +24,8 @@ public:
 
     Errors(const Errors&) = default;
     Errors& operator=(const Errors&) = default;
-    Errors(Errors&&) = default;
-    Errors& operator=(Errors&&) = default;
+    Errors(Errors&&) noexcept = default;
+    Errors& operator=(Errors&&) noexcept = default;
 
     bool ok() const;
     const std::vector<Error>& get_errors() const;

--- a/src/core/errors/errors.hpp
+++ b/src/core/errors/errors.hpp
@@ -19,16 +19,16 @@ using Error = std::variant<ParsingError, ValidationError, RuntimeError>;
 
 class Errors {
 public:
-    Errors() noexcept = default;
-    Errors(Error&& error) noexcept;
+    Errors() = default;
+    Errors(Error&& error);
 
     Errors(const Errors&) = default;
     Errors& operator=(const Errors&) = default;
-    Errors(Errors&&) noexcept = default;
-    Errors& operator=(Errors&&) noexcept = default;
+    Errors(Errors&&) = default;
+    Errors& operator=(Errors&&) = default;
 
-    bool ok() const noexcept;
-    const std::vector<Error>& get_errors() const noexcept;
+    bool ok() const;
+    const std::vector<Error>& get_errors() const;
 
     void add_parsing_error(ParsingError::Code error_code, const std::filesystem::path& filepath, std::string&& message);
     void add_parsing_error(ParsingError&& error);

--- a/src/core/errors/parsing_error.cpp
+++ b/src/core/errors/parsing_error.cpp
@@ -9,13 +9,13 @@ namespace dnd {
 
 ParsingError::ParsingError(
     ParsingError::Code error_code, const std::filesystem::path& filepath, const std::string& message
-) noexcept
+)
     : error_code(error_code), filepath(filepath), error_message(message) {}
 
-ParsingError::Code ParsingError::get_error_code() const noexcept { return error_code; }
+ParsingError::Code ParsingError::get_error_code() const { return error_code; }
 
-const std::filesystem::path& ParsingError::get_filepath() const noexcept { return filepath; }
+const std::filesystem::path& ParsingError::get_filepath() const { return filepath; }
 
-const std::string& ParsingError::get_error_message() const noexcept { return error_message; }
+const std::string& ParsingError::get_error_message() const { return error_message; }
 
 } // namespace dnd

--- a/src/core/errors/parsing_error.hpp
+++ b/src/core/errors/parsing_error.hpp
@@ -12,11 +12,11 @@ class ParsingError {
 public:
     enum class Code;
 
-    ParsingError(Code error_code, const std::filesystem::path& filepath, const std::string& message) noexcept;
+    ParsingError(Code error_code, const std::filesystem::path& filepath, const std::string& message);
 
-    Code get_error_code() const noexcept;
-    const std::filesystem::path& get_filepath() const noexcept;
-    const std::string& get_error_message() const noexcept;
+    Code get_error_code() const;
+    const std::filesystem::path& get_filepath() const;
+    const std::string& get_error_message() const;
 private:
     Code error_code;
     std::filesystem::path filepath;

--- a/src/core/errors/runtime_error.cpp
+++ b/src/core/errors/runtime_error.cpp
@@ -7,12 +7,12 @@
 
 namespace dnd {
 
-RuntimeError::RuntimeError(Code code, const std::string& message) noexcept : code(code), error_message(message) {}
+RuntimeError::RuntimeError(Code code, const std::string& message) : code(code), error_message(message) {}
 
-RuntimeError::RuntimeError(Code code, std::string&& message) noexcept : code(code), error_message(std::move(message)) {}
+RuntimeError::RuntimeError(Code code, std::string&& message) : code(code), error_message(std::move(message)) {}
 
-RuntimeError::Code RuntimeError::get_error_code() const noexcept { return code; }
+RuntimeError::Code RuntimeError::get_error_code() const { return code; }
 
-const std::string& RuntimeError::get_error_message() const noexcept { return error_message; }
+const std::string& RuntimeError::get_error_message() const { return error_message; }
 
 } // namespace dnd

--- a/src/core/errors/runtime_error.hpp
+++ b/src/core/errors/runtime_error.hpp
@@ -11,11 +11,11 @@ class RuntimeError {
 public:
     enum class Code;
 
-    RuntimeError(Code code, const std::string& message) noexcept;
-    RuntimeError(Code code, std::string&& message) noexcept;
+    RuntimeError(Code code, const std::string& message);
+    RuntimeError(Code code, std::string&& message);
 
-    Code get_error_code() const noexcept;
-    const std::string& get_error_message() const noexcept;
+    Code get_error_code() const;
+    const std::string& get_error_message() const;
 private:
     Code code;
     std::string error_message;

--- a/src/core/errors/validation_error.cpp
+++ b/src/core/errors/validation_error.cpp
@@ -8,11 +8,11 @@
 
 namespace dnd {
 
-ValidationError::ValidationError(ValidationError::Code error_code, const std::string& message) noexcept
+ValidationError::ValidationError(ValidationError::Code error_code, const std::string& message)
     : error_code(error_code), error_message(message) {}
 
-ValidationError::Code ValidationError::get_error_code() const noexcept { return error_code; }
+ValidationError::Code ValidationError::get_error_code() const { return error_code; }
 
-const std::string& ValidationError::get_error_message() const noexcept { return error_message; }
+const std::string& ValidationError::get_error_message() const { return error_message; }
 
 } // namespace dnd

--- a/src/core/errors/validation_error.hpp
+++ b/src/core/errors/validation_error.hpp
@@ -13,10 +13,10 @@ class ValidationError {
 public:
     enum class Code;
 
-    ValidationError(Code error_code, const std::string& message) noexcept;
+    ValidationError(Code error_code, const std::string& message);
 
-    Code get_error_code() const noexcept;
-    const std::string& get_error_message() const noexcept;
+    Code get_error_code() const;
+    const std::string& get_error_message() const;
 private:
     Code error_code;
     std::string error_message;

--- a/src/core/groups.hpp
+++ b/src/core/groups.hpp
@@ -15,8 +15,8 @@ public:
     Groups() = default;
     Groups(const Groups&) = delete;
     Groups& operator=(const Groups&) = delete;
-    Groups(Groups&&) = default;
-    Groups& operator=(Groups&&) = default;
+    Groups(Groups&&) noexcept = default;
+    Groups& operator=(Groups&&) noexcept = default;
 
     std::set<std::string> get_group(const std::string& group_name) const;
     std::vector<std::string> get_all_group_names() const;

--- a/src/core/models/character/ability_scores.cpp
+++ b/src/core/models/character/ability_scores.cpp
@@ -10,7 +10,7 @@
 
 namespace dnd {
 
-static int calculate_modifier(int score) noexcept { return score / 2 - 5; }
+static int calculate_modifier(int score) { return score / 2 - 5; }
 
 CreateResult<AbilityScores> AbilityScores::create(Data&& data) {
     Errors errors = validate_ability_scores(data);
@@ -23,7 +23,7 @@ CreateResult<AbilityScores> AbilityScores::create(Data&& data) {
     ));
 }
 
-int AbilityScores::get(Ability ability) const noexcept {
+int AbilityScores::get(Ability ability) const {
     switch (ability) {
         case Ability::STRENGTH:
             return strength;
@@ -42,19 +42,19 @@ int AbilityScores::get(Ability ability) const noexcept {
     }
 }
 
-int AbilityScores::get_strength() const noexcept { return strength; }
+int AbilityScores::get_strength() const { return strength; }
 
-int AbilityScores::get_dexterity() const noexcept { return dexterity; }
+int AbilityScores::get_dexterity() const { return dexterity; }
 
-int AbilityScores::get_constitution() const noexcept { return constitution; }
+int AbilityScores::get_constitution() const { return constitution; }
 
-int AbilityScores::get_intelligence() const noexcept { return intelligence; }
+int AbilityScores::get_intelligence() const { return intelligence; }
 
-int AbilityScores::get_wisdom() const noexcept { return wisdom; }
+int AbilityScores::get_wisdom() const { return wisdom; }
 
-int AbilityScores::get_charisma() const noexcept { return charisma; }
+int AbilityScores::get_charisma() const { return charisma; }
 
-int AbilityScores::get_modifier(Ability ability) const noexcept {
+int AbilityScores::get_modifier(Ability ability) const {
     switch (ability) {
         case Ability::STRENGTH:
             return get_strength_modifier();
@@ -73,22 +73,22 @@ int AbilityScores::get_modifier(Ability ability) const noexcept {
     }
 }
 
-int AbilityScores::get_strength_modifier() const noexcept { return calculate_modifier(strength); }
+int AbilityScores::get_strength_modifier() const { return calculate_modifier(strength); }
 
-int AbilityScores::get_dexterity_modifier() const noexcept { return calculate_modifier(dexterity); }
+int AbilityScores::get_dexterity_modifier() const { return calculate_modifier(dexterity); }
 
-int AbilityScores::get_constitution_modifier() const noexcept { return calculate_modifier(constitution); }
+int AbilityScores::get_constitution_modifier() const { return calculate_modifier(constitution); }
 
-int AbilityScores::get_intelligence_modifier() const noexcept { return calculate_modifier(intelligence); }
+int AbilityScores::get_intelligence_modifier() const { return calculate_modifier(intelligence); }
 
-int AbilityScores::get_wisdom_modifier() const noexcept { return calculate_modifier(wisdom); }
+int AbilityScores::get_wisdom_modifier() const { return calculate_modifier(wisdom); }
 
-int AbilityScores::get_charisma_modifier() const noexcept { return calculate_modifier(charisma); }
+int AbilityScores::get_charisma_modifier() const { return calculate_modifier(charisma); }
 
 
 AbilityScores::AbilityScores(
     int strength, int dexterity, int constitution, int intelligence, int wisdom, int charisma
-) noexcept
+)
     : strength(strength), dexterity(dexterity), constitution(constitution), intelligence(intelligence), wisdom(wisdom),
       charisma(charisma) {}
 

--- a/src/core/models/character/ability_scores.cpp
+++ b/src/core/models/character/ability_scores.cpp
@@ -86,9 +86,7 @@ int AbilityScores::get_wisdom_modifier() const { return calculate_modifier(wisdo
 int AbilityScores::get_charisma_modifier() const { return calculate_modifier(charisma); }
 
 
-AbilityScores::AbilityScores(
-    int strength, int dexterity, int constitution, int intelligence, int wisdom, int charisma
-)
+AbilityScores::AbilityScores(int strength, int dexterity, int constitution, int intelligence, int wisdom, int charisma)
     : strength(strength), dexterity(dexterity), constitution(constitution), intelligence(intelligence), wisdom(wisdom),
       charisma(charisma) {}
 

--- a/src/core/models/character/ability_scores.hpp
+++ b/src/core/models/character/ability_scores.hpp
@@ -17,23 +17,23 @@ public:
 
     static CreateResult<AbilityScores> create(Data&& data);
 
-    int get(Ability ability) const noexcept;
-    int get_strength() const noexcept;
-    int get_dexterity() const noexcept;
-    int get_constitution() const noexcept;
-    int get_intelligence() const noexcept;
-    int get_wisdom() const noexcept;
-    int get_charisma() const noexcept;
+    int get(Ability ability) const;
+    int get_strength() const;
+    int get_dexterity() const;
+    int get_constitution() const;
+    int get_intelligence() const;
+    int get_wisdom() const;
+    int get_charisma() const;
 
-    int get_modifier(Ability ability) const noexcept;
-    int get_strength_modifier() const noexcept;
-    int get_dexterity_modifier() const noexcept;
-    int get_constitution_modifier() const noexcept;
-    int get_intelligence_modifier() const noexcept;
-    int get_wisdom_modifier() const noexcept;
-    int get_charisma_modifier() const noexcept;
+    int get_modifier(Ability ability) const;
+    int get_strength_modifier() const;
+    int get_dexterity_modifier() const;
+    int get_constitution_modifier() const;
+    int get_intelligence_modifier() const;
+    int get_wisdom_modifier() const;
+    int get_charisma_modifier() const;
 private:
-    AbilityScores(int strength, int dexterity, int constitution, int intelligence, int wisdom, int charisma) noexcept;
+    AbilityScores(int strength, int dexterity, int constitution, int intelligence, int wisdom, int charisma);
 
     int strength;
     int dexterity;
@@ -44,7 +44,7 @@ private:
 };
 
 struct AbilityScores::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::array<int, 6> ability_scores;
 };

--- a/src/core/models/character/character.cpp
+++ b/src/core/models/character/character.cpp
@@ -43,7 +43,7 @@ CreateResult<Character> Character::create_for(Data&& data, const Content& conten
             auto [_, sub_errors] = feature_result.data_and_errors();
             return InvalidCreate<Character>(std::move(data), std::move(sub_errors));
         }
-        features.emplace_back(feature_result.value());
+        features.push_back(feature_result.value());
     }
 
     CreateResult<AbilityScores> base_ability_scores_result = AbilityScores::create(
@@ -78,7 +78,7 @@ CreateResult<Character> Character::create_for(Data&& data, const Content& conten
             auto [_, sub_errors] = decision_result.data_and_errors();
             return InvalidCreate<Character>(std::move(data), std::move(sub_errors));
         }
-        decisions.emplace_back(decision_result.value());
+        decisions.push_back(decision_result.value());
     }
 
     return ValidCreate(Character(

--- a/src/core/models/character/character.cpp
+++ b/src/core/models/character/character.cpp
@@ -87,23 +87,23 @@ CreateResult<Character> Character::create_for(Data&& data, const Content& conten
     ));
 }
 
-const std::string& Character::get_name() const noexcept { return name; }
+const std::string& Character::get_name() const { return name; }
 
-const std::string& Character::get_description() const noexcept { return description; }
+const std::string& Character::get_description() const { return description; }
 
-const SourceInfo& Character::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Character::get_source_info() const { return source_info; }
 
-const std::vector<Feature>& Character::get_features() const noexcept { return features; }
+const std::vector<Feature>& Character::get_features() const { return features; }
 
-const std::vector<Choosable>& Character::get_choosables() const noexcept { return choosables; }
+const std::vector<Choosable>& Character::get_choosables() const { return choosables; }
 
-const AbilityScores& Character::get_base_ability_scores() const noexcept { return base_ability_scores; }
+const AbilityScores& Character::get_base_ability_scores() const { return base_ability_scores; }
 
-const FeatureProviders& Character::get_feature_providers() const noexcept { return feature_providers; }
+const FeatureProviders& Character::get_feature_providers() const { return feature_providers; }
 
-const Progression& Character::get_progression() const noexcept { return progression; }
+const Progression& Character::get_progression() const { return progression; }
 
-void Character::for_all_effects_do(std::function<void(const Effects&)> func) const noexcept {
+void Character::for_all_effects_do(std::function<void(const Effects&)> func) const {
     for (const Feature& feature : feature_providers.get_species().get_features()) {
         func(feature.get_main_effects());
     }
@@ -142,7 +142,7 @@ void Character::for_all_effects_do(std::function<void(const Effects&)> func) con
     }
 }
 
-int Character::get_proficiency_bonus() const noexcept {
+int Character::get_proficiency_bonus() const {
     tl::expected<int, RuntimeError> proficiency_bonus_result = proficiency_bonus_for_level(progression.get_level());
     assert(proficiency_bonus_result.has_value());
     return proficiency_bonus_result.value();
@@ -154,7 +154,7 @@ Character::Character(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, std::vector<Feature>&& features,
     AbilityScores&& base_ability_scores, FeatureProviders&& feature_providers, Progression&& progression,
     std::vector<Decision>&& decisions
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       features(std::move(features)), base_ability_scores(std::move(base_ability_scores)),
       feature_providers(std::move(feature_providers)), progression(std::move(progression)),

--- a/src/core/models/character/character_data.hpp
+++ b/src/core/models/character/character_data.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 struct Character::Data : public ValidationData {
 public:
-    std::strong_ordering operator<=>(const Character::Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Character::Data&) const = default;
 
     std::vector<Feature::Data> features_data;
     AbilityScores::Data base_ability_scores_data;

--- a/src/core/models/character/character_without_data.hpp
+++ b/src/core/models/character/character_without_data.hpp
@@ -36,18 +36,18 @@ public:
     Character(Character&&) = default;
     Character& operator=(Character&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::vector<Feature>& get_features() const noexcept;
-    const std::vector<Choosable>& get_choosables() const noexcept;
-    const AbilityScores& get_base_ability_scores() const noexcept;
-    const FeatureProviders& get_feature_providers() const noexcept;
-    const Progression& get_progression() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::vector<Feature>& get_features() const;
+    const std::vector<Choosable>& get_choosables() const;
+    const AbilityScores& get_base_ability_scores() const;
+    const FeatureProviders& get_feature_providers() const;
+    const Progression& get_progression() const;
 
-    int get_proficiency_bonus() const noexcept;
+    int get_proficiency_bonus() const;
 
-    void for_all_effects_do(std::function<void(const Effects&)> func) const noexcept;
+    void for_all_effects_do(std::function<void(const Effects&)> func) const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
@@ -55,7 +55,7 @@ private:
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::vector<Feature>&& features, AbilityScores&& base_ability_scores, FeatureProviders&& feature_providers,
         Progression&& progression, std::vector<Decision>&& decisions
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;

--- a/src/core/models/character/character_without_data.hpp
+++ b/src/core/models/character/character_without_data.hpp
@@ -33,8 +33,8 @@ public:
 
     Character(const Character&) = delete;
     Character& operator=(const Character&) = delete;
-    Character(Character&&) = default;
-    Character& operator=(Character&&) = default;
+    Character(Character&&) noexcept = default;
+    Character& operator=(Character&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/character/decision/decision.cpp
+++ b/src/core/models/character/decision/decision.cpp
@@ -67,10 +67,10 @@ CreateResult<Decision> Decision::create_for(
     return ValidCreate(Decision(*data.get_target(), std::move(effects_result.value())));
 }
 
-CRef<Effects> Decision::get_target() const noexcept { return target; }
+CRef<Effects> Decision::get_target() const { return target; }
 
-const Effects& Decision::get_effects() const noexcept { return effects; }
+const Effects& Decision::get_effects() const { return effects; }
 
-Decision::Decision(CRef<Effects> target, Effects&& effects) noexcept : target(target), effects(std::move(effects)) {}
+Decision::Decision(CRef<Effects> target, Effects&& effects) : target(target), effects(std::move(effects)) {}
 
 } // namespace dnd

--- a/src/core/models/character/decision/decision.cpp
+++ b/src/core/models/character/decision/decision.cpp
@@ -34,7 +34,7 @@ CreateResult<Decision> Decision::create_for(
     for (const std::string& stat_change_str : data.selections["stat_changes"]) {
         StatChange::Data stat_change_data;
         stat_change_data.stat_change_str = stat_change_str;
-        res_data.stat_changes_data.emplace_back(std::move(stat_change_data));
+        res_data.stat_changes_data.push_back(std::move(stat_change_data));
     }
     ins(res_data.extra_spells_holder_data.free_cantrips, std::move(data.selections["cantrips_free"]));
     ins(res_data.extra_spells_holder_data.at_will, std::move(data.selections["spells_at_will"]));

--- a/src/core/models/character/decision/decision.hpp
+++ b/src/core/models/character/decision/decision.hpp
@@ -32,21 +32,21 @@ public:
      * @brief Returns the target of the decision i.e. the effects with the choice that the decision is for
      * @return the target of the decision
      */
-    CRef<Effects> get_target() const noexcept;
-    const Effects& get_effects() const noexcept;
+    CRef<Effects> get_target() const;
+    const Effects& get_effects() const;
 private:
-    Decision(CRef<Effects> target, Effects&& effects) noexcept;
+    Decision(CRef<Effects> target, Effects&& effects);
 
     CRef<Effects> target;
     Effects effects;
 };
 
 struct Decision::Data {
-    Data(const Effects* target) noexcept;
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    Data(const Effects* target);
+    std::strong_ordering operator<=>(const Data&) const = default;
 
-    const Effects* get_target() const noexcept;
-    void set_target(const Effects* new_target) noexcept;
+    const Effects* get_target() const;
+    void set_target(const Effects* new_target);
 
     std::string feature_name;
     std::map<std::string, std::vector<std::string>> selections;
@@ -54,11 +54,11 @@ private:
     const Effects* target;
 };
 
-inline Decision::Data::Data(const Effects* target) noexcept : target(target) {}
+inline Decision::Data::Data(const Effects* target) : target(target) {}
 
-inline const Effects* Decision::Data::get_target() const noexcept { return target; }
+inline const Effects* Decision::Data::get_target() const { return target; }
 
-inline void Decision::Data::set_target(const Effects* new_target) noexcept { target = new_target; }
+inline void Decision::Data::set_target(const Effects* new_target) { target = new_target; }
 
 } // namespace dnd
 

--- a/src/core/models/character/decision/decision.hpp
+++ b/src/core/models/character/decision/decision.hpp
@@ -42,7 +42,7 @@ private:
 };
 
 struct Decision::Data {
-    Data(const Effects* target);
+    Data(const Effects* target) noexcept;
     std::strong_ordering operator<=>(const Data&) const = default;
 
     const Effects* get_target() const;
@@ -54,7 +54,7 @@ private:
     const Effects* target;
 };
 
-inline Decision::Data::Data(const Effects* target) : target(target) {}
+inline Decision::Data::Data(const Effects* target) noexcept : target(target) {}
 
 inline const Effects* Decision::Data::get_target() const { return target; }
 

--- a/src/core/models/character/decision/decision.hpp
+++ b/src/core/models/character/decision/decision.hpp
@@ -25,8 +25,8 @@ public:
 
     Decision(const Decision&) = delete;
     Decision& operator=(const Decision&) = delete;
-    Decision(Decision&&) = default;
-    Decision& operator=(Decision&&) = default;
+    Decision(Decision&&) noexcept = default;
+    Decision& operator=(Decision&&) noexcept = default;
 
     /**
      * @brief Returns the target of the decision i.e. the effects with the choice that the decision is for

--- a/src/core/models/character/feature_providers.cpp
+++ b/src/core/models/character/feature_providers.cpp
@@ -34,21 +34,21 @@ CreateResult<FeatureProviders> FeatureProviders::create_for(Data&& data, const C
     return ValidCreate(FeatureProviders(species, subspecies, cls, subclass));
 }
 
-const Species& FeatureProviders::get_species() const noexcept { return species; }
+const Species& FeatureProviders::get_species() const { return species; }
 
-OptCRef<Subspecies> FeatureProviders::get_subspecies() const noexcept { return subspecies; }
+OptCRef<Subspecies> FeatureProviders::get_subspecies() const { return subspecies; }
 
-const Class& FeatureProviders::get_class() const noexcept { return cls; }
+const Class& FeatureProviders::get_class() const { return cls; }
 
-OptCRef<Subclass> FeatureProviders::get_subclass() const noexcept { return subclass; }
+OptCRef<Subclass> FeatureProviders::get_subclass() const { return subclass; }
 
-bool FeatureProviders::has_subspecies() const noexcept { return subspecies.has_value(); }
+bool FeatureProviders::has_subspecies() const { return subspecies.has_value(); }
 
-bool FeatureProviders::has_subclass() const noexcept { return subclass.has_value(); }
+bool FeatureProviders::has_subclass() const { return subclass.has_value(); }
 
 FeatureProviders::FeatureProviders(
     const Species& species, OptCRef<Subspecies> subspecies, const Class& cls, OptCRef<Subclass> subclass
-) noexcept
+)
     : species(std::cref(species)), subspecies(subspecies), cls(std::cref(cls)), subclass(subclass) {}
 
 } // namespace dnd

--- a/src/core/models/character/feature_providers.hpp
+++ b/src/core/models/character/feature_providers.hpp
@@ -24,17 +24,17 @@ public:
 
     static CreateResult<FeatureProviders> create_for(Data&& data, const Content& content);
 
-    const Species& get_species() const noexcept;
-    OptCRef<Subspecies> get_subspecies() const noexcept;
-    const Class& get_class() const noexcept;
-    OptCRef<Subclass> get_subclass() const noexcept;
+    const Species& get_species() const;
+    OptCRef<Subspecies> get_subspecies() const;
+    const Class& get_class() const;
+    OptCRef<Subclass> get_subclass() const;
 
-    bool has_subspecies() const noexcept;
-    bool has_subclass() const noexcept;
+    bool has_subspecies() const;
+    bool has_subclass() const;
 private:
     FeatureProviders(
         const Species& species, OptCRef<Subspecies> subspecies, const Class& cls, OptCRef<Subclass> subclass
-    ) noexcept;
+    );
 
     std::reference_wrapper<const Species> species;
     OptCRef<Subspecies> subspecies;
@@ -43,7 +43,7 @@ private:
 };
 
 struct FeatureProviders::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string species_name;
     std::string subspecies_name;

--- a/src/core/models/character/progression.cpp
+++ b/src/core/models/character/progression.cpp
@@ -17,13 +17,13 @@ CreateResult<Progression> Progression::create(Data&& data) {
     return ValidCreate(Progression(data.level, data.xp, std::move(data.hit_dice_rolls)));
 }
 
-int Progression::get_level() const noexcept { return level; }
+int Progression::get_level() const { return level; }
 
-int Progression::get_xp() const noexcept { return xp; }
+int Progression::get_xp() const { return xp; }
 
-const std::vector<int>& Progression::get_hit_dice_rolls() const noexcept { return hit_dice_rolls; }
+const std::vector<int>& Progression::get_hit_dice_rolls() const { return hit_dice_rolls; }
 
-Progression::Progression(int level, int xp, std::vector<int>&& hit_dice_rolls) noexcept
+Progression::Progression(int level, int xp, std::vector<int>&& hit_dice_rolls)
     : level(level), xp(xp), hit_dice_rolls(std::move(hit_dice_rolls)) {}
 
 } // namespace dnd

--- a/src/core/models/character/progression.hpp
+++ b/src/core/models/character/progression.hpp
@@ -18,11 +18,11 @@ public:
 
     static CreateResult<Progression> create(Data&& data);
 
-    int get_level() const noexcept;
-    int get_xp() const noexcept;
-    const std::vector<int>& get_hit_dice_rolls() const noexcept;
+    int get_level() const;
+    int get_xp() const;
+    const std::vector<int>& get_hit_dice_rolls() const;
 private:
-    Progression(int level, int xp, std::vector<int>&& hit_dice_rolls) noexcept;
+    Progression(int level, int xp, std::vector<int>&& hit_dice_rolls);
 
     int level;
     int xp;
@@ -30,7 +30,7 @@ private:
 };
 
 struct Progression::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     int level;
     int xp;

--- a/src/core/models/class/class.cpp
+++ b/src/core/models/class/class.cpp
@@ -104,23 +104,23 @@ CreateResult<Class> Class::create_for(Data&& data, const Content& content) {
     ));
 }
 
-const std::string& Class::get_name() const noexcept { return name; }
+const std::string& Class::get_name() const { return name; }
 
-const std::string& Class::get_description() const noexcept { return description; }
+const std::string& Class::get_description() const { return description; }
 
-const SourceInfo& Class::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Class::get_source_info() const { return source_info; }
 
-const std::vector<ClassFeature>& Class::get_features() const noexcept { return features; }
+const std::vector<ClassFeature>& Class::get_features() const { return features; }
 
-bool Class::has_spellcasting() const noexcept { return spellcasting != nullptr; }
+bool Class::has_spellcasting() const { return spellcasting != nullptr; }
 
-const Spellcasting* Class::get_spellcasting() const noexcept { return spellcasting.get(); }
+const Spellcasting* Class::get_spellcasting() const { return spellcasting.get(); }
 
-OptCRef<ClassFeature> Class::get_subclass_feature() const noexcept { return subclass_feature; }
+OptCRef<ClassFeature> Class::get_subclass_feature() const { return subclass_feature; }
 
-const Dice& Class::get_hit_dice() const noexcept { return hit_dice; }
+const Dice& Class::get_hit_dice() const { return hit_dice; }
 
-const ImportantLevels& Class::get_important_levels() const noexcept { return important_levels; }
+const ImportantLevels& Class::get_important_levels() const { return important_levels; }
 
 void Class::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
@@ -128,7 +128,7 @@ Class::Class(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path,
     std::vector<ClassFeature>&& features, OptCRef<ClassFeature> subclass_feature, Dice hit_dice,
     ImportantLevels&& important_levels, std::unique_ptr<Spellcasting>&& spellcasting
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       features(std::move(features)), spellcasting(std::move(spellcasting)), subclass_feature(subclass_feature),
       hit_dice(std::move(hit_dice)), important_levels(std::move(important_levels)) {}

--- a/src/core/models/class/class.cpp
+++ b/src/core/models/class/class.cpp
@@ -62,10 +62,10 @@ CreateResult<Class> Class::create_for(Data&& data, const Content& content) {
         ClassFeature feature = feature_result.value();
         if (feature.get_name() == data.subclass_feature_name) {
             subclass_level = determine_subclass_level(feature_data);
-            features.emplace_back(std::move(feature));
+            features.push_back(std::move(feature));
             subclass_feature = features.back();
         } else {
-            features.emplace_back(std::move(feature));
+            features.push_back(std::move(feature));
         }
     }
     assert(subclass_level != -1);

--- a/src/core/models/class/class.hpp
+++ b/src/core/models/class/class.hpp
@@ -30,8 +30,8 @@ public:
 
     Class(const Class&) = delete;
     Class& operator=(const Class&) = delete;
-    Class(Class&&) = default;
-    Class& operator=(Class&&) = default;
+    Class(Class&&) noexcept = default;
+    Class& operator=(Class&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/class/class.hpp
+++ b/src/core/models/class/class.hpp
@@ -33,15 +33,15 @@ public:
     Class(Class&&) = default;
     Class& operator=(Class&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::vector<ClassFeature>& get_features() const noexcept;
-    bool has_spellcasting() const noexcept;
-    const Spellcasting* get_spellcasting() const noexcept;
-    OptCRef<ClassFeature> get_subclass_feature() const noexcept;
-    const Dice& get_hit_dice() const noexcept;
-    const ImportantLevels& get_important_levels() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::vector<ClassFeature>& get_features() const;
+    bool has_spellcasting() const;
+    const Spellcasting* get_spellcasting() const;
+    OptCRef<ClassFeature> get_subclass_feature() const;
+    const Dice& get_hit_dice() const;
+    const ImportantLevels& get_important_levels() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
@@ -49,7 +49,7 @@ private:
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::vector<ClassFeature>&& features, OptCRef<ClassFeature> subclass_feature, Dice hit_dice,
         ImportantLevels&& important_levels, std::unique_ptr<Spellcasting>&& spellcasting = nullptr
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -62,7 +62,7 @@ private:
 };
 
 struct Class::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     Spellcasting::Data spellcasting_data;
     std::vector<ClassFeature::Data> features_data;

--- a/src/core/models/class/important_levels.cpp
+++ b/src/core/models/class/important_levels.cpp
@@ -26,11 +26,11 @@ CreateResult<ImportantLevels> ImportantLevels::create(Data&& data, int subclass_
     return ValidCreate(ImportantLevels(std::move(data.feat_levels), subclass_level));
 }
 
-const std::set<int>& ImportantLevels::get_feat_levels() const noexcept { return feat_levels; }
+const std::set<int>& ImportantLevels::get_feat_levels() const { return feat_levels; }
 
-int ImportantLevels::get_subclass_level() const noexcept { return subclass_level; }
+int ImportantLevels::get_subclass_level() const { return subclass_level; }
 
-ImportantLevels::ImportantLevels(std::set<int>&& feat_levels, int subclass_level) noexcept
+ImportantLevels::ImportantLevels(std::set<int>&& feat_levels, int subclass_level)
     : feat_levels(std::move(feat_levels)), subclass_level(subclass_level) {}
 
 } // namespace dnd

--- a/src/core/models/class/important_levels.hpp
+++ b/src/core/models/class/important_levels.hpp
@@ -15,17 +15,17 @@ public:
 
     static CreateResult<ImportantLevels> create(Data&& data, int subclass_level);
 
-    const std::set<int>& get_feat_levels() const noexcept;
-    int get_subclass_level() const noexcept;
+    const std::set<int>& get_feat_levels() const;
+    int get_subclass_level() const;
 private:
-    ImportantLevels(std::set<int>&& feat_levels, int subclass_level) noexcept;
+    ImportantLevels(std::set<int>&& feat_levels, int subclass_level);
 
     std::set<int> feat_levels;
     int subclass_level;
 };
 
 struct ImportantLevels::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::set<int> feat_levels;
 };

--- a/src/core/models/effects/choice/choice.cpp
+++ b/src/core/models/effects/choice/choice.cpp
@@ -99,14 +99,14 @@ static std::vector<std::unique_ptr<ContentFilter>> spell_filters(Choice::Data& d
         SpellFilter spell_filter;
         SelectionFilter<std::string>& selection_filter = spell_filter.name_filter.emplace<1>();
         selection_filter.set(SelectionFilterType::IS_IN, data.explicit_choices);
-        filters.emplace_back(std::make_unique<SpellFilter>(std::move(spell_filter)));
+        filters.push_back(std::make_unique<SpellFilter>(std::move(spell_filter)));
     }
     for (const std::string& group_name : data.group_names) {
         SpellFilter spell_filter;
         if (data.attribute_name == "cantrips_free") {
-            filters.emplace_back(create_cantrip_filter(group_name));
+            filters.push_back(create_cantrip_filter(group_name));
         } else {
-            filters.emplace_back(create_spell_filter(group_name));
+            filters.push_back(create_spell_filter(group_name));
         }
     }
     return filters;

--- a/src/core/models/effects/choice/choice.cpp
+++ b/src/core/models/effects/choice/choice.cpp
@@ -151,9 +151,9 @@ CreateResult<Choice> Choice::create_for(Data&& data, const Content& content) {
     ));
 }
 
-const std::string& Choice::get_attribute_name() const noexcept { return attribute_name; }
+const std::string& Choice::get_attribute_name() const { return attribute_name; }
 
-int Choice::get_amount() const noexcept { return amount; }
+int Choice::get_amount() const { return amount; }
 
 std::set<std::string> Choice::possible_values(const Content& content) const {
     std::set<std::string> possible_values;
@@ -205,7 +205,7 @@ std::set<std::string> Choice::possible_values(const Content& content) const {
 Choice::Choice(
     ChoiceType type, std::vector<std::unique_ptr<ContentFilter>>&& filters, std::string&& attribute_name, int amount,
     std::vector<std::string>&& group_names, std::vector<std::string>&& explicit_choices
-) noexcept
+)
     : type(type), attribute_name(std::move(attribute_name)), amount(amount), group_names(std::move(group_names)),
       explicit_choices(std::move(explicit_choices)), filters(std::move(filters)) {}
 

--- a/src/core/models/effects/choice/choice.hpp
+++ b/src/core/models/effects/choice/choice.hpp
@@ -23,15 +23,15 @@ public:
 
     static CreateResult<Choice> create_for(Data&& data, const Content& content);
 
-    const std::string& get_attribute_name() const noexcept;
-    int get_amount() const noexcept;
+    const std::string& get_attribute_name() const;
+    int get_amount() const;
 
     std::set<std::string> possible_values(const Content& content) const;
 private:
     Choice(
         ChoiceType type, std::vector<std::unique_ptr<ContentFilter>>&& filters, std::string&& attribute_name,
         int amount, std::vector<std::string>&& group_names, std::vector<std::string>&& explicit_choices
-    ) noexcept;
+    );
 
     ChoiceType type;
     std::string attribute_name;
@@ -42,7 +42,7 @@ private:
 };
 
 struct Choice::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string attribute_name;
     int amount;

--- a/src/core/models/effects/choice/choice_rules.cpp
+++ b/src/core/models/effects/choice/choice_rules.cpp
@@ -33,7 +33,7 @@ static constexpr std::array<std::pair<std::string_view, ChoiceType>, 22> valid_a
     std::pair("condition_immunities", ChoiceType::STRING),
 };
 
-bool is_valid_choice_attribute_name(const std::string& attribute_name) noexcept {
+bool is_valid_choice_attribute_name(const std::string& attribute_name) {
     for (const auto& [valid_attribute_name, _] : valid_attribute_names) {
         if (valid_attribute_name == attribute_name) {
             return true;
@@ -63,7 +63,7 @@ static constexpr std::array<std::pair<std::string_view, std::string_view>, 9> va
     std::pair("condition_immunities", "conditions"),
 };
 
-bool attribute_name_implies_group(const std::string& attribute_name) noexcept {
+bool attribute_name_implies_group(const std::string& attribute_name) {
     for (const auto& [group_name, _] : valid_group_names) {
         if (group_name == attribute_name) {
             return true;

--- a/src/core/models/effects/choice/choice_rules.hpp
+++ b/src/core/models/effects/choice/choice_rules.hpp
@@ -22,7 +22,7 @@ enum class ChoiceType {
  * @param attribute_name the attribute name to check
  * @return "true" if the given attribute name is a valid choice attribute name, "false" otherwise
  */
-bool is_valid_choice_attribute_name(const std::string& attribute_name) noexcept;
+bool is_valid_choice_attribute_name(const std::string& attribute_name);
 
 /**
  * @brief Determines the choice type for the given attribute name
@@ -37,7 +37,7 @@ ChoiceType choice_type_for_attribute_name(const std::string& attribute_name);
  * @param attribute_name the attribute name to check
  * @return "true" if the given attribute name implies a group of strings, "false" otherwise
  */
-bool attribute_name_implies_group(const std::string& attribute_name) noexcept;
+bool attribute_name_implies_group(const std::string& attribute_name);
 
 /**
  * @brief Determines the group name for the given attribute name if the attribute name implies a group of strings

--- a/src/core/models/effects/condition/condition.cpp
+++ b/src/core/models/effects/condition/condition.cpp
@@ -15,7 +15,7 @@ static constexpr std::array<std::pair<const char*, bool (*)(int, int)>, 6> compa
     std::pair(">", [](int a, int b) { return a > b; }),   std::pair("<", [](int a, int b) { return a < b; }),
 };
 
-Condition::Condition(const std::string& left_side_identifier, const std::string& operator_name) noexcept
+Condition::Condition(const std::string& left_side_identifier, const std::string& operator_name)
     : left_side_identifier(left_side_identifier), comparison_operator(nullptr) {
     for (const auto& [op_name, op_func] : comparison_operators) {
         if (op_name == operator_name) {
@@ -25,7 +25,7 @@ Condition::Condition(const std::string& left_side_identifier, const std::string&
     }
 }
 
-Condition::Condition(std::string_view left_side_identifier, std::string_view operator_name) noexcept
+Condition::Condition(std::string_view left_side_identifier, std::string_view operator_name)
     : left_side_identifier(left_side_identifier), comparison_operator(nullptr) {
     for (const auto& [op_name, op_func] : comparison_operators) {
         if (op_name == operator_name) {

--- a/src/core/models/effects/condition/condition.hpp
+++ b/src/core/models/effects/condition/condition.hpp
@@ -14,7 +14,7 @@ class Condition {
 public:
     struct Data;
 
-    virtual ~Condition() noexcept = default;
+    virtual ~Condition() = default;
     /**
      * @brief Evaluates the condition for given attributes and constants
      * @param attributes a map of attributes
@@ -33,21 +33,21 @@ protected:
      * @param left_side_identifier the identifier on the left side of the condition
      * @param operator_name the name of the operator
      */
-    Condition(const std::string& left_side_identifier, const std::string& operator_name) noexcept;
+    Condition(const std::string& left_side_identifier, const std::string& operator_name);
     /**
      * @brief Constructs a condition with the given left side identifier and operator
      * CAREFUL: if the operator is not found, the construction doesn't fail
      * @param left_side_identifier the identifier on the left side of the condition
      * @param operator_name the name of the operator
      */
-    Condition(std::string_view left_side_identifier, std::string_view operator_name) noexcept;
+    Condition(std::string_view left_side_identifier, std::string_view operator_name);
 
     std::string left_side_identifier;
     std::function<bool(int, int)> comparison_operator;
 };
 
 struct Condition::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string condition_str;
 };

--- a/src/core/models/effects/condition/identifier_condition.cpp
+++ b/src/core/models/effects/condition/identifier_condition.cpp
@@ -14,12 +14,12 @@ namespace dnd {
 
 IdentifierCondition::IdentifierCondition(
     const std::string& left_side_identifier, const std::string& operator_name, const std::string& right_side_identifier
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side_identifier(right_side_identifier) {}
 
 IdentifierCondition::IdentifierCondition(
     std::string_view left_side_identifier, std::string_view operator_name, std::string_view right_side_identifier
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side_identifier(right_side_identifier) {}
 
 bool IdentifierCondition::evaluate(

--- a/src/core/models/effects/condition/identifier_condition.hpp
+++ b/src/core/models/effects/condition/identifier_condition.hpp
@@ -28,7 +28,7 @@ public:
     IdentifierCondition(
         const std::string& left_side_identifier, const std::string& operator_name,
         const std::string& right_side_identifier
-    ) noexcept;
+    );
     /**
      * @brief Constructs a condition with the given identifiers and operator
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -39,7 +39,7 @@ public:
      */
     IdentifierCondition(
         std::string_view left_side_identifier, std::string_view operator_name, std::string_view right_side_identifier
-    ) noexcept;
+    );
     /**
      * @brief Evaluates the condition for given attributes and constants
      * @param attributes a map of attributes

--- a/src/core/models/effects/condition/literal_condition.cpp
+++ b/src/core/models/effects/condition/literal_condition.cpp
@@ -13,32 +13,32 @@ namespace dnd {
 
 LiteralCondition::LiteralCondition(
     const std::string& left_side_identifier, const std::string& operator_name, bool right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(right_side) {}
 
 LiteralCondition::LiteralCondition(
     std::string_view left_side_identifier, std::string_view operator_name, bool right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(right_side) {}
 
 LiteralCondition::LiteralCondition(
     const std::string& left_side_identifier, const std::string& operator_name, int right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(right_side * 100) {}
 
 LiteralCondition::LiteralCondition(
     std::string_view left_side_identifier, std::string_view operator_name, int right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(right_side * 100) {}
 
 LiteralCondition::LiteralCondition(
     const std::string& left_side_identifier, const std::string& operator_name, float right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(static_cast<int>(right_side * 100)) {}
 
 LiteralCondition::LiteralCondition(
     std::string_view left_side_identifier, std::string_view operator_name, float right_side
-) noexcept
+)
     : Condition(left_side_identifier, operator_name), right_side(static_cast<int>(right_side * 100)) {}
 
 bool LiteralCondition::evaluate(

--- a/src/core/models/effects/condition/literal_condition.hpp
+++ b/src/core/models/effects/condition/literal_condition.hpp
@@ -24,9 +24,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(
-        const std::string& left_side_identifier, const std::string& operator_name, bool right_side
-    );
+    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, bool right_side);
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side boolean
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -44,9 +42,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(
-        const std::string& left_side_identifier, const std::string& operator_name, int right_side
-    );
+    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, int right_side);
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side integer
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -64,9 +60,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(
-        const std::string& left_side_identifier, const std::string& operator_name, float right_side
-    );
+    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, float right_side);
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side float
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to

--- a/src/core/models/effects/condition/literal_condition.hpp
+++ b/src/core/models/effects/condition/literal_condition.hpp
@@ -26,7 +26,7 @@ public:
      */
     LiteralCondition(
         const std::string& left_side_identifier, const std::string& operator_name, bool right_side
-    ) noexcept;
+    );
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side boolean
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -35,7 +35,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, bool right_side) noexcept;
+    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, bool right_side);
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side integer
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -46,7 +46,7 @@ public:
      */
     LiteralCondition(
         const std::string& left_side_identifier, const std::string& operator_name, int right_side
-    ) noexcept;
+    );
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side integer
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -55,7 +55,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, int right_side) noexcept;
+    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, int right_side);
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side float
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -66,7 +66,7 @@ public:
      */
     LiteralCondition(
         const std::string& left_side_identifier, const std::string& operator_name, float right_side
-    ) noexcept;
+    );
     /**
      * @brief Constructs a condition with the given left side identifier, operator, and right side float
      * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
@@ -75,7 +75,7 @@ public:
      * @param operator_name the name of the operator
      * @param right_side the right side of the condition
      */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, float right_side) noexcept;
+    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, float right_side);
     /**
      * @brief Evaluates the condition for given attributes and constants
      * @param attributes a map of attributes

--- a/src/core/models/effects/effects.cpp
+++ b/src/core/models/effects/effects.cpp
@@ -39,7 +39,7 @@ CreateResult<Effects> Effects::create_for(Data&& data, const Content& content) {
             auto [_, sub_errors] = condition_result.data_and_errors();
             return InvalidCreate<Effects>(std::move(data), std::move(sub_errors));
         }
-        activation_conditions.emplace_back(condition_result.value());
+        activation_conditions.push_back(condition_result.value());
     }
 
     std::vector<Choice> choices;
@@ -50,7 +50,7 @@ CreateResult<Effects> Effects::create_for(Data&& data, const Content& content) {
             auto [_, sub_errors] = choice_result.data_and_errors();
             return InvalidCreate<Effects>(std::move(data), std::move(sub_errors));
         }
-        choices.emplace_back(choice_result.value());
+        choices.push_back(choice_result.value());
     }
 
     std::vector<std::unique_ptr<StatChange>> stat_changes;
@@ -61,7 +61,7 @@ CreateResult<Effects> Effects::create_for(Data&& data, const Content& content) {
             auto [_, sub_errors] = stat_change_result.data_and_errors();
             return InvalidCreate<Effects>(std::move(data), std::move(sub_errors));
         }
-        stat_changes.emplace_back(stat_change_result.value());
+        stat_changes.push_back(stat_change_result.value());
     }
 
     CreateResult<ActionHolder> action_holder_result = ActionHolder::create(std::move(data.action_holder_data));

--- a/src/core/models/effects/effects.cpp
+++ b/src/core/models/effects/effects.cpp
@@ -106,27 +106,27 @@ Effects::Effects(
     std::vector<std::unique_ptr<Condition>>&& activation_conditions, std::vector<Choice>&& choices,
     std::vector<std::unique_ptr<StatChange>>&& stat_changes, ActionHolder&& action_holder,
     ExtraSpellsHolder&& extra_spells_holder, ProficiencyHolder&& proficiency_holder, RIVHolder&& riv_holder
-) noexcept
+)
     : activation_conditions(std::move(activation_conditions)), choices(std::move(choices)),
       stat_changes(std::move(stat_changes)), actions(std::move(action_holder)),
       extra_spells(std::move(extra_spells_holder)), proficiencies(std::move(proficiency_holder)),
       rivs(std::move(riv_holder)) {}
 
-const std::vector<std::unique_ptr<Condition>>& Effects::get_activation_conditions() const noexcept {
+const std::vector<std::unique_ptr<Condition>>& Effects::get_activation_conditions() const {
     return activation_conditions;
 }
 
-const std::vector<Choice>& Effects::get_choices() const noexcept { return choices; }
+const std::vector<Choice>& Effects::get_choices() const { return choices; }
 
-const std::vector<std::unique_ptr<StatChange>>& Effects::get_stat_changes() const noexcept { return stat_changes; }
+const std::vector<std::unique_ptr<StatChange>>& Effects::get_stat_changes() const { return stat_changes; }
 
-const ActionHolder& Effects::get_actions() const noexcept { return actions; }
+const ActionHolder& Effects::get_actions() const { return actions; }
 
-const ExtraSpellsHolder& Effects::get_extra_spells() const noexcept { return extra_spells; }
+const ExtraSpellsHolder& Effects::get_extra_spells() const { return extra_spells; }
 
-const ProficiencyHolder& Effects::get_proficiencies() const noexcept { return proficiencies; }
+const ProficiencyHolder& Effects::get_proficiencies() const { return proficiencies; }
 
-const RIVHolder& Effects::get_rivs() const noexcept { return rivs; }
+const RIVHolder& Effects::get_rivs() const { return rivs; }
 
 bool Effects::empty() const {
     return activation_conditions.empty() && stat_changes.empty() && actions.empty() && extra_spells.empty()

--- a/src/core/models/effects/effects.hpp
+++ b/src/core/models/effects/effects.hpp
@@ -37,8 +37,8 @@ public:
 
     Effects(const Effects&) = delete;
     Effects& operator=(const Effects&) = delete;
-    Effects(Effects&&) = default;
-    Effects& operator=(Effects&&) = default;
+    Effects(Effects&&) noexcept = default;
+    Effects& operator=(Effects&&) noexcept = default;
 
     const std::vector<std::unique_ptr<Condition>>& get_activation_conditions() const;
     const std::vector<Choice>& get_choices() const;

--- a/src/core/models/effects/effects.hpp
+++ b/src/core/models/effects/effects.hpp
@@ -32,21 +32,21 @@ public:
         std::vector<std::unique_ptr<Condition>>&& activation_conditions, std::vector<Choice>&& choices,
         std::vector<std::unique_ptr<StatChange>>&& stat_changes, ActionHolder&& action_holder,
         ExtraSpellsHolder&& extra_spells_holder, ProficiencyHolder&& proficiency_holder, RIVHolder&& riv_holder
-    ) noexcept;
-    virtual ~Effects() noexcept = default;
+    );
+    virtual ~Effects() = default;
 
     Effects(const Effects&) = delete;
     Effects& operator=(const Effects&) = delete;
-    Effects(Effects&&) noexcept = default;
-    Effects& operator=(Effects&&) noexcept = default;
+    Effects(Effects&&) = default;
+    Effects& operator=(Effects&&) = default;
 
-    const std::vector<std::unique_ptr<Condition>>& get_activation_conditions() const noexcept;
-    const std::vector<Choice>& get_choices() const noexcept;
-    const std::vector<std::unique_ptr<StatChange>>& get_stat_changes() const noexcept;
-    const ActionHolder& get_actions() const noexcept;
-    const ExtraSpellsHolder& get_extra_spells() const noexcept;
-    const ProficiencyHolder& get_proficiencies() const noexcept;
-    const RIVHolder& get_rivs() const noexcept;
+    const std::vector<std::unique_ptr<Condition>>& get_activation_conditions() const;
+    const std::vector<Choice>& get_choices() const;
+    const std::vector<std::unique_ptr<StatChange>>& get_stat_changes() const;
+    const ActionHolder& get_actions() const;
+    const ExtraSpellsHolder& get_extra_spells() const;
+    const ProficiencyHolder& get_proficiencies() const;
+    const RIVHolder& get_rivs() const;
 
     bool empty() const;
 
@@ -73,7 +73,7 @@ private:
 };
 
 struct Effects::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::vector<Condition::Data> activation_conditions_data;
     std::vector<Choice::Data> choices_data;

--- a/src/core/models/effects/stat_change/identifier_stat_change.cpp
+++ b/src/core/models/effects/stat_change/identifier_stat_change.cpp
@@ -15,13 +15,13 @@ namespace dnd {
 IdentifierStatChange::IdentifierStatChange(
     const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name,
     const std::string& value_identifier
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value_identifier(value_identifier) {}
 
 IdentifierStatChange::IdentifierStatChange(
     std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name,
     std::string_view value_identifier
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value_identifier(value_identifier) {}
 
 void IdentifierStatChange::apply_to(

--- a/src/core/models/effects/stat_change/identifier_stat_change.hpp
+++ b/src/core/models/effects/stat_change/identifier_stat_change.hpp
@@ -28,7 +28,7 @@ public:
     IdentifierStatChange(
         const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name,
         const std::string& value_identifier
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and value
      * identifier for the operation.
@@ -41,7 +41,7 @@ public:
     IdentifierStatChange(
         std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name,
         std::string_view value_identifier
-    ) noexcept;
+    );
     /**
      * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
      * @param attributes character attributes may be used for calculation and one of them will be changed

--- a/src/core/models/effects/stat_change/literal_stat_change.cpp
+++ b/src/core/models/effects/stat_change/literal_stat_change.cpp
@@ -14,32 +14,32 @@ namespace dnd {
 
 LiteralStatChange::LiteralStatChange(
     const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, bool value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value)) {}
 
 LiteralStatChange::LiteralStatChange(
     std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, bool value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value)) {}
 
 LiteralStatChange::LiteralStatChange(
     const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, int value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(value * 100) {}
 
 LiteralStatChange::LiteralStatChange(
     std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, int value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(value * 100) {}
 
 LiteralStatChange::LiteralStatChange(
     const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, float value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value * 100)) {}
 
 LiteralStatChange::LiteralStatChange(
     std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, float value
-) noexcept
+)
     : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value * 100)) {}
 
 void LiteralStatChange::apply_to(

--- a/src/core/models/effects/stat_change/literal_stat_change.hpp
+++ b/src/core/models/effects/stat_change/literal_stat_change.hpp
@@ -27,7 +27,7 @@ public:
      */
     LiteralStatChange(
         const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, bool value
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and boolean value
      * for the operation.
@@ -39,7 +39,7 @@ public:
      */
     LiteralStatChange(
         std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, bool value
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and integer value
      * for the operation.
@@ -51,7 +51,7 @@ public:
      */
     LiteralStatChange(
         const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, int value
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and integer value
      * for the operation.
@@ -63,7 +63,7 @@ public:
      */
     LiteralStatChange(
         std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, int value
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and float value
      * for the operation.
@@ -75,7 +75,7 @@ public:
      */
     LiteralStatChange(
         const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, float value
-    ) noexcept;
+    );
     /**
      * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and float value
      * for the operation.
@@ -87,7 +87,7 @@ public:
      */
     LiteralStatChange(
         std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, float value
-    ) noexcept;
+    );
     /**
      * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
      * @param attributes character attributes may be used for calculation and one of them will be changed

--- a/src/core/models/effects/stat_change/stat_change.cpp
+++ b/src/core/models/effects/stat_change/stat_change.cpp
@@ -7,7 +7,6 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <utility>
 
 namespace dnd {
@@ -36,9 +35,7 @@ static constexpr std::array<std::pair<const char*, int (*)(int, int)>, 7> mathem
     std::pair("min", [](int a, int b) { return std::min(a, b); }),
 };
 
-StatChange::StatChange(
-    const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name
-)
+StatChange::StatChange(const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name)
     : affected_attribute(affected_attribute), mathematical_operation(nullptr), time(time) {
     for (const auto& [name, operation] : mathematical_operations) {
         if (name == operation_name) {
@@ -48,9 +45,7 @@ StatChange::StatChange(
     }
 }
 
-StatChange::StatChange(
-    std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name
-)
+StatChange::StatChange(std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name)
     : affected_attribute(affected_attribute), mathematical_operation(nullptr), time(time) {
     for (const auto& [name, operation] : mathematical_operations) {
         if (name == operation_name) {

--- a/src/core/models/effects/stat_change/stat_change.cpp
+++ b/src/core/models/effects/stat_change/stat_change.cpp
@@ -38,7 +38,7 @@ static constexpr std::array<std::pair<const char*, int (*)(int, int)>, 7> mathem
 
 StatChange::StatChange(
     const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name
-) noexcept
+)
     : affected_attribute(affected_attribute), mathematical_operation(nullptr), time(time) {
     for (const auto& [name, operation] : mathematical_operations) {
         if (name == operation_name) {
@@ -50,7 +50,7 @@ StatChange::StatChange(
 
 StatChange::StatChange(
     std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name
-) noexcept
+)
     : affected_attribute(affected_attribute), mathematical_operation(nullptr), time(time) {
     for (const auto& [name, operation] : mathematical_operations) {
         if (name == operation_name) {
@@ -60,6 +60,6 @@ StatChange::StatChange(
     }
 }
 
-StatChangeTime StatChange::get_time() const noexcept { return time; }
+StatChangeTime StatChange::get_time() const { return time; }
 
 } // namespace dnd

--- a/src/core/models/effects/stat_change/stat_change.hpp
+++ b/src/core/models/effects/stat_change/stat_change.hpp
@@ -27,9 +27,9 @@ class StatChange {
 public:
     struct Data;
 
-    virtual ~StatChange() noexcept = default;
+    virtual ~StatChange() = default;
 
-    StatChangeTime get_time() const noexcept;
+    StatChangeTime get_time() const;
 
     /**
      * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
@@ -47,7 +47,7 @@ protected:
      * @param time the time at which this stat change should be applied in the order of execution
      * @param operation_name the name of the mathematical operation that is performed when applying this stat change
      */
-    StatChange(const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name) noexcept;
+    StatChange(const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name);
     /**
      * @brief Constructs an Effect with the attribute it affects, its execution time, and the name of the operation.
      * CAREFUL: if the operation is not found, the construction doesn't fail
@@ -55,7 +55,7 @@ protected:
      * @param time the time at which this stat change should be applied in the order of execution
      * @param operation_name the name of the mathematical operation that is performed when applying this stat change
      */
-    StatChange(std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name) noexcept;
+    StatChange(std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name);
 
     std::string affected_attribute;
     std::function<int(int, int)> mathematical_operation;
@@ -64,7 +64,7 @@ private:
 };
 
 struct StatChange::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string stat_change_str;
 };

--- a/src/core/models/effects/subholders/action_holder.cpp
+++ b/src/core/models/effects/subholders/action_holder.cpp
@@ -20,11 +20,11 @@ CreateResult<ActionHolder> ActionHolder::create(Data&& data) {
     return ValidCreate(ActionHolder(std::move(data.actions), std::move(data.bonus_actions), std::move(data.reactions)));
 }
 
-const std::map<std::string, std::string>& ActionHolder::get_actions() const noexcept { return actions; }
+const std::map<std::string, std::string>& ActionHolder::get_actions() const { return actions; }
 
-const std::map<std::string, std::string>& ActionHolder::get_bonus_actions() const noexcept { return bonus_actions; }
+const std::map<std::string, std::string>& ActionHolder::get_bonus_actions() const { return bonus_actions; }
 
-const std::map<std::string, std::string>& ActionHolder::get_reactions() const noexcept { return reactions; }
+const std::map<std::string, std::string>& ActionHolder::get_reactions() const { return reactions; }
 
 bool ActionHolder::empty() const { return actions.empty() && bonus_actions.empty() && reactions.empty(); }
 
@@ -37,7 +37,7 @@ void ActionHolder::merge(ActionHolder&& other) {
 ActionHolder::ActionHolder(
     std::map<std::string, std::string>&& actions, std::map<std::string, std::string>&& bonus_actions,
     std::map<std::string, std::string>&& reactions
-) noexcept
+)
     : actions(std::move(actions)), bonus_actions(std::move(bonus_actions)), reactions(std::move(reactions)) {}
 
 } // namespace dnd

--- a/src/core/models/effects/subholders/action_holder.hpp
+++ b/src/core/models/effects/subholders/action_holder.hpp
@@ -45,9 +45,7 @@ struct ActionHolder::Data {
     std::map<std::string, std::string> reactions;
 };
 
-inline bool ActionHolder::Data::empty() const {
-    return actions.empty() && bonus_actions.empty() && reactions.empty();
-}
+inline bool ActionHolder::Data::empty() const { return actions.empty() && bonus_actions.empty() && reactions.empty(); }
 
 } // namespace dnd
 

--- a/src/core/models/effects/subholders/action_holder.hpp
+++ b/src/core/models/effects/subholders/action_holder.hpp
@@ -19,9 +19,9 @@ public:
 
     static CreateResult<ActionHolder> create(Data&& data);
 
-    const std::map<std::string, std::string>& get_actions() const noexcept;
-    const std::map<std::string, std::string>& get_bonus_actions() const noexcept;
-    const std::map<std::string, std::string>& get_reactions() const noexcept;
+    const std::map<std::string, std::string>& get_actions() const;
+    const std::map<std::string, std::string>& get_bonus_actions() const;
+    const std::map<std::string, std::string>& get_reactions() const;
 
     bool empty() const;
     void merge(ActionHolder&& other);
@@ -29,7 +29,7 @@ private:
     ActionHolder(
         std::map<std::string, std::string>&& actions, std::map<std::string, std::string>&& bonus_actions,
         std::map<std::string, std::string>&& reactions
-    ) noexcept;
+    );
 
     std::map<std::string, std::string> actions;
     std::map<std::string, std::string> bonus_actions;
@@ -37,15 +37,15 @@ private:
 };
 
 struct ActionHolder::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
-    bool empty() const noexcept;
+    std::strong_ordering operator<=>(const Data&) const = default;
+    bool empty() const;
 
     std::map<std::string, std::string> actions;
     std::map<std::string, std::string> bonus_actions;
     std::map<std::string, std::string> reactions;
 };
 
-inline bool ActionHolder::Data::empty() const noexcept {
+inline bool ActionHolder::Data::empty() const {
     return actions.empty() && bonus_actions.empty() && reactions.empty();
 }
 

--- a/src/core/models/effects/subholders/extra_spells_holder.cpp
+++ b/src/core/models/effects/subholders/extra_spells_holder.cpp
@@ -52,13 +52,9 @@ const std::vector<const Spell*>& ExtraSpellsHolder::get_free_once_a_day() const 
 
 const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known() const { return spells_known; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known_included() const {
-    return spells_known_included;
-}
+const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known_included() const { return spells_known_included; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_added_to_spell_list() const {
-    return added_to_spell_list;
-}
+const std::vector<const Spell*>& ExtraSpellsHolder::get_added_to_spell_list() const { return added_to_spell_list; }
 
 bool ExtraSpellsHolder::empty() const {
     return free_cantrips.empty() && at_will.empty() && innate.empty() && free_once_a_day.empty() && spells_known.empty()

--- a/src/core/models/effects/subholders/extra_spells_holder.cpp
+++ b/src/core/models/effects/subholders/extra_spells_holder.cpp
@@ -42,21 +42,21 @@ CreateResult<ExtraSpellsHolder> ExtraSpellsHolder::create_for(Data&& data, const
     ));
 }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_free_cantrips() const noexcept { return free_cantrips; }
+const std::vector<const Spell*>& ExtraSpellsHolder::get_free_cantrips() const { return free_cantrips; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_at_will() const noexcept { return at_will; }
+const std::vector<const Spell*>& ExtraSpellsHolder::get_at_will() const { return at_will; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_innate() const noexcept { return innate; }
+const std::vector<const Spell*>& ExtraSpellsHolder::get_innate() const { return innate; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_free_once_a_day() const noexcept { return free_once_a_day; }
+const std::vector<const Spell*>& ExtraSpellsHolder::get_free_once_a_day() const { return free_once_a_day; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known() const noexcept { return spells_known; }
+const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known() const { return spells_known; }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known_included() const noexcept {
+const std::vector<const Spell*>& ExtraSpellsHolder::get_spells_known_included() const {
     return spells_known_included;
 }
 
-const std::vector<const Spell*>& ExtraSpellsHolder::get_added_to_spell_list() const noexcept {
+const std::vector<const Spell*>& ExtraSpellsHolder::get_added_to_spell_list() const {
     return added_to_spell_list;
 }
 
@@ -83,7 +83,7 @@ ExtraSpellsHolder::ExtraSpellsHolder(
     std::vector<const Spell*>&& free_cantrips, std::vector<const Spell*>&& at_will, std::vector<const Spell*>&& innate,
     std::vector<const Spell*>&& free_once_a_day, std::vector<const Spell*>&& spells_known,
     std::vector<const Spell*>&& spells_known_included, std::vector<const Spell*>&& added_to_spell_list
-) noexcept
+)
     : free_cantrips(std::move(free_cantrips)), at_will(std::move(at_will)), innate(std::move(innate)),
       free_once_a_day(std::move(free_once_a_day)), spells_known(std::move(spells_known)),
       spells_known_included(std::move(spells_known_included)), added_to_spell_list(std::move(added_to_spell_list)) {}

--- a/src/core/models/effects/subholders/extra_spells_holder.hpp
+++ b/src/core/models/effects/subholders/extra_spells_holder.hpp
@@ -28,41 +28,41 @@ public:
      * @brief Returns the cantrips that do not count against the number of cantrips known
      * @return the cantrips that do not count against the number of cantrips known
      */
-    const std::vector<const Spell*>& get_free_cantrips() const noexcept;
+    const std::vector<const Spell*>& get_free_cantrips() const;
     /**
      * @brief Returns the spells that you can cast without expending a spell slot or material components
      * @return the spells that you can cast without expending a spell slot or material components
      */
-    const std::vector<const Spell*>& get_at_will() const noexcept;
+    const std::vector<const Spell*>& get_at_will() const;
     /**
      * @brief Returns the spells that you can cast once a day (or rather once between two long rests)
      * these spells do not require spell slots
      * @return the spells that you can cast once a day (or rather once between two long rests)
      */
-    const std::vector<const Spell*>& get_innate() const noexcept;
+    const std::vector<const Spell*>& get_innate() const;
     /**
      * @brief Returns the spells that you can cast once a day (or rather once between two long rests)
      * these spells do require spell slots
      * @return the spells that you can cast once a day (or rather once between two long rests)
      */
-    const std::vector<const Spell*>& get_free_once_a_day() const noexcept;
+    const std::vector<const Spell*>& get_free_once_a_day() const;
     /**
      * @brief Returns the spells that are added to your spell list and you know them / you always have them prepared
      * (these spells do not count to the number of spells you know)
      * @return the spells that are added to your spell list and you know them / you always have them prepared
      */
-    const std::vector<const Spell*>& get_spells_known() const noexcept;
+    const std::vector<const Spell*>& get_spells_known() const;
     /**
      * @brief Returns the spells that are added to your spell list and you know them
      * these spells do count to the number of spells you know
      * @return the spells that are added to your spell list and you know them
      */
-    const std::vector<const Spell*>& get_spells_known_included() const noexcept;
+    const std::vector<const Spell*>& get_spells_known_included() const;
     /**
      * @brief Returns the spells that are added to your spell list
      * @return the spells that are added to your spell list
      */
-    const std::vector<const Spell*>& get_added_to_spell_list() const noexcept;
+    const std::vector<const Spell*>& get_added_to_spell_list() const;
 
     bool empty() const;
     void merge(ExtraSpellsHolder&& other);
@@ -72,7 +72,7 @@ private:
         std::vector<const Spell*>&& innate, std::vector<const Spell*>&& free_once_a_day,
         std::vector<const Spell*>&& spells_known, std::vector<const Spell*>&& spells_known_included,
         std::vector<const Spell*>&& added_to_spell_list
-    ) noexcept;
+    );
 
     // cantrips that do not count against the number of cantrips known
     std::vector<const Spell*> free_cantrips;
@@ -95,8 +95,8 @@ private:
 };
 
 struct ExtraSpellsHolder::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
-    bool empty() const noexcept;
+    std::strong_ordering operator<=>(const Data&) const = default;
+    bool empty() const;
 
     // cantrips that do not count against the number of cantrips known
     std::set<std::string> free_cantrips;
@@ -118,7 +118,7 @@ struct ExtraSpellsHolder::Data {
     std::set<std::string> added_to_spell_list;
 };
 
-inline bool ExtraSpellsHolder::Data::empty() const noexcept {
+inline bool ExtraSpellsHolder::Data::empty() const {
     return free_cantrips.empty() && at_will.empty() && innate.empty() && free_once_a_day.empty() && spells_known.empty()
            && spells_known_included.empty() && added_to_spell_list.empty();
 }

--- a/src/core/models/effects/subholders/proficiency_holder.cpp
+++ b/src/core/models/effects/subholders/proficiency_holder.cpp
@@ -34,21 +34,13 @@ CreateResult<ProficiencyHolder> ProficiencyHolder::create_for(Data&& data, const
     ));
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_armor_proficiencies() const {
-    return armor_proficiencies;
-}
+const std::vector<std::string>& ProficiencyHolder::get_armor_proficiencies() const { return armor_proficiencies; }
 
-const std::vector<std::string>& ProficiencyHolder::get_weapon_proficiencies() const {
-    return weapon_proficiencies;
-}
+const std::vector<std::string>& ProficiencyHolder::get_weapon_proficiencies() const { return weapon_proficiencies; }
 
-const std::vector<std::string>& ProficiencyHolder::get_tool_proficiencies() const {
-    return tool_proficiencies;
-}
+const std::vector<std::string>& ProficiencyHolder::get_tool_proficiencies() const { return tool_proficiencies; }
 
-const std::vector<std::string>& ProficiencyHolder::get_skill_proficiencies() const {
-    return skill_proficiencies;
-}
+const std::vector<std::string>& ProficiencyHolder::get_skill_proficiencies() const { return skill_proficiencies; }
 
 const std::vector<std::string>& ProficiencyHolder::get_saving_throw_proficiencies() const {
     return saving_throw_proficiencies;

--- a/src/core/models/effects/subholders/proficiency_holder.cpp
+++ b/src/core/models/effects/subholders/proficiency_holder.cpp
@@ -34,29 +34,29 @@ CreateResult<ProficiencyHolder> ProficiencyHolder::create_for(Data&& data, const
     ));
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_armor_proficiencies() const noexcept {
+const std::vector<std::string>& ProficiencyHolder::get_armor_proficiencies() const {
     return armor_proficiencies;
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_weapon_proficiencies() const noexcept {
+const std::vector<std::string>& ProficiencyHolder::get_weapon_proficiencies() const {
     return weapon_proficiencies;
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_tool_proficiencies() const noexcept {
+const std::vector<std::string>& ProficiencyHolder::get_tool_proficiencies() const {
     return tool_proficiencies;
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_skill_proficiencies() const noexcept {
+const std::vector<std::string>& ProficiencyHolder::get_skill_proficiencies() const {
     return skill_proficiencies;
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_saving_throw_proficiencies() const noexcept {
+const std::vector<std::string>& ProficiencyHolder::get_saving_throw_proficiencies() const {
     return saving_throw_proficiencies;
 }
 
-const std::vector<std::string>& ProficiencyHolder::get_known_languages() const noexcept { return known_languages; }
+const std::vector<std::string>& ProficiencyHolder::get_known_languages() const { return known_languages; }
 
-const std::vector<std::string>& ProficiencyHolder::get_senses() const noexcept { return senses; }
+const std::vector<std::string>& ProficiencyHolder::get_senses() const { return senses; }
 
 bool ProficiencyHolder::empty() const {
     return armor_proficiencies.empty() && weapon_proficiencies.empty() && tool_proficiencies.empty()
@@ -98,7 +98,7 @@ ProficiencyHolder::ProficiencyHolder(
     std::vector<std::string>&& armor, std::vector<std::string>&& weapons, std::vector<std::string>&& tools,
     std::vector<std::string>&& skills, std::vector<std::string>&& saving_throws, std::vector<std::string>&& languages,
     std::vector<std::string>&& senses
-) noexcept
+)
     : armor_proficiencies(std::move(armor)), weapon_proficiencies(std::move(weapons)),
       tool_proficiencies(std::move(tools)), skill_proficiencies(std::move(skills)),
       saving_throw_proficiencies(std::move(saving_throws)), known_languages(std::move(languages)),

--- a/src/core/models/effects/subholders/proficiency_holder.hpp
+++ b/src/core/models/effects/subholders/proficiency_holder.hpp
@@ -24,13 +24,13 @@ public:
 
     static CreateResult<ProficiencyHolder> create_for(Data&& data, const Content& content);
 
-    const std::vector<std::string>& get_armor_proficiencies() const noexcept;
-    const std::vector<std::string>& get_weapon_proficiencies() const noexcept;
-    const std::vector<std::string>& get_tool_proficiencies() const noexcept;
-    const std::vector<std::string>& get_skill_proficiencies() const noexcept;
-    const std::vector<std::string>& get_saving_throw_proficiencies() const noexcept;
-    const std::vector<std::string>& get_known_languages() const noexcept;
-    const std::vector<std::string>& get_senses() const noexcept;
+    const std::vector<std::string>& get_armor_proficiencies() const;
+    const std::vector<std::string>& get_weapon_proficiencies() const;
+    const std::vector<std::string>& get_tool_proficiencies() const;
+    const std::vector<std::string>& get_skill_proficiencies() const;
+    const std::vector<std::string>& get_saving_throw_proficiencies() const;
+    const std::vector<std::string>& get_known_languages() const;
+    const std::vector<std::string>& get_senses() const;
 
     bool empty() const;
     void merge(ProficiencyHolder&& other);
@@ -39,7 +39,7 @@ private:
         std::vector<std::string>&& armor, std::vector<std::string>&& weapons, std::vector<std::string>&& tools,
         std::vector<std::string>&& skills, std::vector<std::string>&& saving_throws,
         std::vector<std::string>&& languages, std::vector<std::string>&& senses
-    ) noexcept;
+    );
 
     std::vector<std::string> armor_proficiencies;
     std::vector<std::string> weapon_proficiencies;
@@ -51,8 +51,8 @@ private:
 };
 
 struct ProficiencyHolder::Data {
-    std::strong_ordering operator<=>(const ProficiencyHolder::Data&) const noexcept = default;
-    bool empty() const noexcept;
+    std::strong_ordering operator<=>(const ProficiencyHolder::Data&) const = default;
+    bool empty() const;
 
     // the types of armor the character is proficient with
     std::set<std::string> armor;
@@ -70,7 +70,7 @@ struct ProficiencyHolder::Data {
     std::set<std::string> senses;
 };
 
-inline bool ProficiencyHolder::Data::empty() const noexcept {
+inline bool ProficiencyHolder::Data::empty() const {
     return armor.empty() && weapons.empty() && tools.empty() && skills.empty() && saving_throws.empty()
            && languages.empty() && senses.empty();
 }

--- a/src/core/models/effects/subholders/riv_holder.cpp
+++ b/src/core/models/effects/subholders/riv_holder.cpp
@@ -39,9 +39,7 @@ const std::vector<std::string>& RIVHolder::get_damage_resistances() const { retu
 
 const std::vector<std::string>& RIVHolder::get_damage_immunities() const { return damage_immunities; }
 
-const std::vector<std::string>& RIVHolder::get_damage_vulnerabilities() const {
-    return damage_vulnerabilities;
-}
+const std::vector<std::string>& RIVHolder::get_damage_vulnerabilities() const { return damage_vulnerabilities; }
 
 const std::vector<std::string>& RIVHolder::get_condition_immunities() const { return condition_immunities; }
 

--- a/src/core/models/effects/subholders/riv_holder.cpp
+++ b/src/core/models/effects/subholders/riv_holder.cpp
@@ -35,15 +35,15 @@ CreateResult<RIVHolder> RIVHolder::create_for(Data&& data, const Content& conten
     ));
 }
 
-const std::vector<std::string>& RIVHolder::get_damage_resistances() const noexcept { return damage_resistances; }
+const std::vector<std::string>& RIVHolder::get_damage_resistances() const { return damage_resistances; }
 
-const std::vector<std::string>& RIVHolder::get_damage_immunities() const noexcept { return damage_immunities; }
+const std::vector<std::string>& RIVHolder::get_damage_immunities() const { return damage_immunities; }
 
-const std::vector<std::string>& RIVHolder::get_damage_vulnerabilities() const noexcept {
+const std::vector<std::string>& RIVHolder::get_damage_vulnerabilities() const {
     return damage_vulnerabilities;
 }
 
-const std::vector<std::string>& RIVHolder::get_condition_immunities() const noexcept { return condition_immunities; }
+const std::vector<std::string>& RIVHolder::get_condition_immunities() const { return condition_immunities; }
 
 bool RIVHolder::empty() const {
     return damage_resistances.empty() && damage_immunities.empty() && damage_vulnerabilities.empty()
@@ -72,7 +72,7 @@ void RIVHolder::merge(RIVHolder&& other) {
 RIVHolder::RIVHolder(
     std::vector<std::string>&& damage_resistances, std::vector<std::string>&& damage_immunities,
     std::vector<std::string>&& damage_vulnerabilities, std::vector<std::string>&& condition_immunities
-) noexcept
+)
     : damage_resistances(std::move(damage_resistances)), damage_immunities(std::move(damage_immunities)),
       damage_vulnerabilities(std::move(damage_vulnerabilities)), condition_immunities(std::move(condition_immunities)) {
 }

--- a/src/core/models/effects/subholders/riv_holder.hpp
+++ b/src/core/models/effects/subholders/riv_holder.hpp
@@ -23,10 +23,10 @@ public:
 
     static CreateResult<RIVHolder> create_for(Data&& data, const Content& content);
 
-    const std::vector<std::string>& get_damage_resistances() const noexcept;
-    const std::vector<std::string>& get_damage_immunities() const noexcept;
-    const std::vector<std::string>& get_damage_vulnerabilities() const noexcept;
-    const std::vector<std::string>& get_condition_immunities() const noexcept;
+    const std::vector<std::string>& get_damage_resistances() const;
+    const std::vector<std::string>& get_damage_immunities() const;
+    const std::vector<std::string>& get_damage_vulnerabilities() const;
+    const std::vector<std::string>& get_condition_immunities() const;
 
     bool empty() const;
     void merge(RIVHolder&& other);
@@ -34,7 +34,7 @@ private:
     RIVHolder(
         std::vector<std::string>&& damage_resistances, std::vector<std::string>&& damage_immunities,
         std::vector<std::string>&& damage_vulnerabilities, std::vector<std::string>&& condition_immunities
-    ) noexcept;
+    );
 
     std::vector<std::string> damage_resistances;
     std::vector<std::string> damage_immunities;
@@ -43,8 +43,8 @@ private:
 };
 
 struct RIVHolder::Data {
-    std::strong_ordering operator<=>(const RIVHolder::Data&) const noexcept = default;
-    bool empty() const noexcept;
+    std::strong_ordering operator<=>(const RIVHolder::Data&) const = default;
+    bool empty() const;
 
     std::set<std::string> damage_resistances;
     std::set<std::string> damage_immunities;
@@ -52,7 +52,7 @@ struct RIVHolder::Data {
     std::set<std::string> condition_immunities;
 };
 
-inline bool RIVHolder::Data::empty() const noexcept {
+inline bool RIVHolder::Data::empty() const {
     return damage_resistances.empty() && damage_immunities.empty() && damage_vulnerabilities.empty()
            && condition_immunities.empty();
 }

--- a/src/core/models/effects_provider/choosable.cpp
+++ b/src/core/models/effects_provider/choosable.cpp
@@ -30,7 +30,7 @@ CreateResult<Choosable> Choosable::create_for(Data&& data, const Content& conten
             auto [_, sub_errors] = prerequisite_result.data_and_errors();
             return InvalidCreate<Choosable>(std::move(data), std::move(sub_errors));
         }
-        prerequisites.emplace_back(prerequisite_result.value());
+        prerequisites.push_back(prerequisite_result.value());
     }
 
     CreateResult<Effects> main_part_result = Effects::create_for(std::move(data.main_effects_data), content);

--- a/src/core/models/effects_provider/choosable.cpp
+++ b/src/core/models/effects_provider/choosable.cpp
@@ -46,24 +46,24 @@ CreateResult<Choosable> Choosable::create_for(Data&& data, const Content& conten
     ));
 }
 
-const std::string& Choosable::get_name() const noexcept { return name; }
+const std::string& Choosable::get_name() const { return name; }
 
-const std::string& Choosable::get_description() const noexcept { return description; }
+const std::string& Choosable::get_description() const { return description; }
 
-const SourceInfo& Choosable::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Choosable::get_source_info() const { return source_info; }
 
-const Effects& Choosable::get_main_effects() const noexcept { return main_effects; }
+const Effects& Choosable::get_main_effects() const { return main_effects; }
 
-const std::string& Choosable::get_type() const noexcept { return type; }
+const std::string& Choosable::get_type() const { return type; }
 
-const std::vector<std::unique_ptr<Condition>>& Choosable::get_prerequisites() const noexcept { return prerequisites; }
+const std::vector<std::unique_ptr<Condition>>& Choosable::get_prerequisites() const { return prerequisites; }
 
 void Choosable::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Choosable::Choosable(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, std::string&& type,
     std::vector<std::unique_ptr<Condition>>&& prerequisites, Effects&& main_effects
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       main_effects(std::move(main_effects)), type(type), prerequisites(std::move(prerequisites)) {}
 

--- a/src/core/models/effects_provider/choosable.hpp
+++ b/src/core/models/effects_provider/choosable.hpp
@@ -30,8 +30,8 @@ public:
 
     Choosable(const Choosable&) = delete;
     Choosable& operator=(const Choosable&) = delete;
-    Choosable(Choosable&&) = default;
-    Choosable& operator=(Choosable&&) = default;
+    Choosable(Choosable&&) noexcept = default;
+    Choosable& operator=(Choosable&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/effects_provider/choosable.hpp
+++ b/src/core/models/effects_provider/choosable.hpp
@@ -33,19 +33,19 @@ public:
     Choosable(Choosable&&) = default;
     Choosable& operator=(Choosable&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const Effects& get_main_effects() const noexcept override;
-    const std::string& get_type() const noexcept;
-    const std::vector<std::unique_ptr<Condition>>& get_prerequisites() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const Effects& get_main_effects() const override;
+    const std::string& get_type() const;
+    const std::vector<std::unique_ptr<Condition>>& get_prerequisites() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
     Choosable(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path, std::string&& type,
         std::vector<std::unique_ptr<Condition>>&& prerequisites, Effects&& main_effects
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -56,7 +56,7 @@ private:
 };
 
 struct Choosable::Data : public Feature::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string type;
     std::vector<Condition::Data> prerequisites_data;

--- a/src/core/models/effects_provider/class_feature.cpp
+++ b/src/core/models/effects_provider/class_feature.cpp
@@ -52,16 +52,16 @@ CreateResult<ClassFeature> ClassFeature::create_for(Data&& data, const Content& 
     ));
 }
 
-int ClassFeature::get_level() const noexcept { return level; }
+int ClassFeature::get_level() const { return level; }
 
-const std::map<int, Effects>& ClassFeature::get_higher_level_effects() const noexcept { return higher_level_effects; }
+const std::map<int, Effects>& ClassFeature::get_higher_level_effects() const { return higher_level_effects; }
 
 void ClassFeature::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 ClassFeature::ClassFeature(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, int level,
     Effects&& main_effects, std::map<int, Effects>&& higher_level_effects
-) noexcept
+)
     : Feature(std::move(name), std::move(description), std::move(source_path), std::move(main_effects)), level(level),
       higher_level_effects(std::move(higher_level_effects)) {}
 

--- a/src/core/models/effects_provider/class_feature.hpp
+++ b/src/core/models/effects_provider/class_feature.hpp
@@ -29,8 +29,8 @@ public:
 
     ClassFeature(const ClassFeature&) = delete;
     ClassFeature& operator=(const ClassFeature&) = delete;
-    ClassFeature(ClassFeature&&) = default;
-    ClassFeature& operator=(ClassFeature&&) = default;
+    ClassFeature(ClassFeature&&) noexcept = default;
+    ClassFeature& operator=(ClassFeature&&) noexcept = default;
 
     int get_level() const;
     const std::map<int, Effects>& get_higher_level_effects() const;

--- a/src/core/models/effects_provider/class_feature.hpp
+++ b/src/core/models/effects_provider/class_feature.hpp
@@ -32,8 +32,8 @@ public:
     ClassFeature(ClassFeature&&) = default;
     ClassFeature& operator=(ClassFeature&&) = default;
 
-    int get_level() const noexcept;
-    const std::map<int, Effects>& get_higher_level_effects() const noexcept;
+    int get_level() const;
+    const std::map<int, Effects>& get_higher_level_effects() const;
 
     /**
      * @brief Accepts a visitor
@@ -44,14 +44,14 @@ private:
     ClassFeature(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path, int level,
         Effects&& main_effects, std::map<int, Effects>&& higher_level_parts = {}
-    ) noexcept;
+    );
 
     int level;
     std::map<int, Effects> higher_level_effects; // careful when changing the type here, some code relies on order
 };
 
 struct ClassFeature::Data : public Feature::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     int level;
     std::map<int, Effects::Data> higher_level_effects_data;

--- a/src/core/models/effects_provider/effects_provider.hpp
+++ b/src/core/models/effects_provider/effects_provider.hpp
@@ -13,7 +13,7 @@ class Effects;
 class EffectsProvider {
 public:
     virtual ~EffectsProvider() = default;
-    virtual const Effects& get_main_effects() const noexcept = 0;
+    virtual const Effects& get_main_effects() const = 0;
 };
 
 } // namespace dnd

--- a/src/core/models/effects_provider/feature.cpp
+++ b/src/core/models/effects_provider/feature.cpp
@@ -34,19 +34,19 @@ CreateResult<Feature> Feature::create_for(Data&& data, const Content& content) {
     );
 }
 
-const std::string& Feature::get_name() const noexcept { return name; }
+const std::string& Feature::get_name() const { return name; }
 
-const std::string& Feature::get_description() const noexcept { return description; }
+const std::string& Feature::get_description() const { return description; }
 
-const SourceInfo& Feature::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Feature::get_source_info() const { return source_info; }
 
-const Effects& Feature::get_main_effects() const noexcept { return main_effects; }
+const Effects& Feature::get_main_effects() const { return main_effects; }
 
 void Feature::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Feature::Feature(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, Effects&& main_effects
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       main_effects(std::move(main_effects)) {}
 

--- a/src/core/models/effects_provider/feature.hpp
+++ b/src/core/models/effects_provider/feature.hpp
@@ -19,9 +19,6 @@ namespace dnd {
 class Content;
 class ContentVisitor;
 
-/**
- * @brief A class representing a simple feature provided by a class, subclass, species, subspecies, or character.
- */
 class Feature : public ContentPiece, public EffectsProvider {
 public:
     struct Data;
@@ -40,9 +37,7 @@ public:
 
     virtual void accept_visitor(ContentVisitor& visitor) const override;
 protected:
-    Feature(
-        std::string&& name, std::string&& description, std::filesystem::path&& source_path, Effects&& main_effects
-    );
+    Feature(std::string&& name, std::string&& description, std::filesystem::path&& source_path, Effects&& main_effects);
 private:
     std::string name;
     std::string description;

--- a/src/core/models/effects_provider/feature.hpp
+++ b/src/core/models/effects_provider/feature.hpp
@@ -30,8 +30,8 @@ public:
 
     Feature(const Feature&) = delete;
     Feature& operator=(const Feature&) = delete;
-    Feature(Feature&&) = default;
-    Feature& operator=(Feature&&) = default;
+    Feature(Feature&&) noexcept = default;
+    Feature& operator=(Feature&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/effects_provider/feature.hpp
+++ b/src/core/models/effects_provider/feature.hpp
@@ -33,16 +33,16 @@ public:
     Feature(Feature&&) = default;
     Feature& operator=(Feature&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const Effects& get_main_effects() const noexcept override;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const Effects& get_main_effects() const override;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override;
 protected:
     Feature(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path, Effects&& main_effects
-    ) noexcept;
+    );
 private:
     std::string name;
     std::string description;
@@ -51,7 +51,7 @@ private:
 };
 
 struct Feature::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     Effects::Data main_effects_data;
 };

--- a/src/core/models/item/item.cpp
+++ b/src/core/models/item/item.cpp
@@ -27,22 +27,22 @@ CreateResult<Item> Item::create(Data&& data) {
     ));
 }
 
-const std::string& Item::get_name() const noexcept { return name; }
+const std::string& Item::get_name() const { return name; }
 
-const std::string& Item::get_description() const noexcept { return description; }
+const std::string& Item::get_description() const { return description; }
 
-const SourceInfo& Item::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Item::get_source_info() const { return source_info; }
 
-const std::string& Item::get_cosmetic_description() const noexcept { return cosmetic_description; }
+const std::string& Item::get_cosmetic_description() const { return cosmetic_description; }
 
-bool Item::requires_attunement() const noexcept { return attunement; }
+bool Item::requires_attunement() const { return attunement; }
 
 void Item::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Item::Item(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path,
     std::string&& cosmetic_description, bool requires_attunement
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       cosmetic_description(std::move(cosmetic_description)), attunement(requires_attunement) {}
 

--- a/src/core/models/item/item.hpp
+++ b/src/core/models/item/item.hpp
@@ -21,18 +21,18 @@ public:
 
     static CreateResult<Item> create(Data&& item_data);
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::string& get_cosmetic_description() const noexcept;
-    bool requires_attunement() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::string& get_cosmetic_description() const;
+    bool requires_attunement() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
     Item(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::string&& cosmetic_description, bool requires_attunement
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -42,7 +42,7 @@ private:
 };
 
 struct Item::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string cosmetic_description;
     bool requires_attunement;

--- a/src/core/models/source_info.cpp
+++ b/src/core/models/source_info.cpp
@@ -7,7 +7,7 @@
 
 namespace dnd {
 
-static std::string nth_parent_stem(const std::filesystem::path& path, int n) noexcept {
+static std::string nth_parent_stem(const std::filesystem::path& path, int n) {
     std::filesystem::path parent = path;
     for (int i = 0; i < n; ++i) {
         parent = parent.parent_path();
@@ -15,7 +15,7 @@ static std::string nth_parent_stem(const std::filesystem::path& path, int n) noe
     return parent.stem().string();
 }
 
-static std::string beautify_source_path(const std::filesystem::path& source_path) noexcept {
+static std::string beautify_source_path(const std::filesystem::path& source_path) {
     std::filesystem::path relative_path = std::filesystem::relative(
         source_path, source_path.parent_path().parent_path()
     );
@@ -23,14 +23,14 @@ static std::string beautify_source_path(const std::filesystem::path& source_path
     return relative_path.string();
 }
 
-SourceInfo::SourceInfo(const std::filesystem::path& source_path) noexcept
+SourceInfo::SourceInfo(const std::filesystem::path& source_path)
     : source_path(source_path), beautified_source_path(), source_book(nth_parent_stem(source_path, 3) == "general"),
       source_group_name(nth_parent_stem(source_path, 2)), source_type_name(nth_parent_stem(source_path, 1)),
       source_name(source_path.stem().string()) {
     beautified_source_path = beautify_source_path(this->source_path);
 }
 
-SourceInfo::SourceInfo(std::filesystem::path&& source_path) noexcept
+SourceInfo::SourceInfo(std::filesystem::path&& source_path)
     : source_path(std::move(source_path)), beautified_source_path(),
       source_book(nth_parent_stem(this->source_path, 3) == "general"),
       source_group_name(nth_parent_stem(this->source_path, 2)), source_type_name(nth_parent_stem(this->source_path, 1)),
@@ -38,16 +38,16 @@ SourceInfo::SourceInfo(std::filesystem::path&& source_path) noexcept
     beautified_source_path = beautify_source_path(this->source_path);
 }
 
-const std::filesystem::path& SourceInfo::get_source_path() const noexcept { return source_path; }
+const std::filesystem::path& SourceInfo::get_source_path() const { return source_path; }
 
-const std::string& SourceInfo::get_beautified_source_path() const noexcept { return beautified_source_path; }
+const std::string& SourceInfo::get_beautified_source_path() const { return beautified_source_path; }
 
-bool SourceInfo::is_from_source_book() const noexcept { return source_book; }
+bool SourceInfo::is_from_source_book() const { return source_book; }
 
-const std::string& SourceInfo::get_source_group_name() const noexcept { return source_group_name; }
+const std::string& SourceInfo::get_source_group_name() const { return source_group_name; }
 
-const std::string& SourceInfo::get_source_type_name() const noexcept { return source_type_name; }
+const std::string& SourceInfo::get_source_type_name() const { return source_type_name; }
 
-const std::string& SourceInfo::get_source_name() const noexcept { return source_name; }
+const std::string& SourceInfo::get_source_name() const { return source_name; }
 
 } // namespace dnd

--- a/src/core/models/source_info.hpp
+++ b/src/core/models/source_info.hpp
@@ -10,23 +10,23 @@ namespace dnd {
 
 class SourceInfo {
 public:
-    SourceInfo(const std::filesystem::path& source_path) noexcept;
-    SourceInfo(std::filesystem::path&& source_path) noexcept;
+    SourceInfo(const std::filesystem::path& source_path);
+    SourceInfo(std::filesystem::path&& source_path);
 
-    const std::string& get_source_name() const noexcept;
-    const std::filesystem::path& get_source_path() const noexcept;
-    const std::string& get_beautified_source_path() const noexcept;
-    bool is_from_source_book() const noexcept;
+    const std::string& get_source_name() const;
+    const std::filesystem::path& get_source_path() const;
+    const std::string& get_beautified_source_path() const;
+    bool is_from_source_book() const;
     /**
      * @brief Returns the name of the source group (source book name or campaign name)
      * @return name of the source book or campaign the content piece is part of
      */
-    const std::string& get_source_group_name() const noexcept;
+    const std::string& get_source_group_name() const;
     /**
      * @brief Returns the name of the content piece source directory
      * @return the name of the content piece source directory
      */
-    const std::string& get_source_type_name() const noexcept;
+    const std::string& get_source_type_name() const;
 private:
     std::filesystem::path source_path;
     std::string beautified_source_path;

--- a/src/core/models/species/species.cpp
+++ b/src/core/models/species/species.cpp
@@ -37,22 +37,22 @@ CreateResult<Species> Species::create_for(Data&& data, const Content& content) {
     ));
 }
 
-const std::string& Species::get_name() const noexcept { return name; }
+const std::string& Species::get_name() const { return name; }
 
-const std::string& Species::get_description() const noexcept { return description; }
+const std::string& Species::get_description() const { return description; }
 
-const SourceInfo& Species::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Species::get_source_info() const { return source_info; }
 
-const std::vector<Feature>& Species::get_features() const noexcept { return features; }
+const std::vector<Feature>& Species::get_features() const { return features; }
 
-bool Species::has_subspecies() const noexcept { return subspecies; }
+bool Species::has_subspecies() const { return subspecies; }
 
 void Species::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Species::Species(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, std::vector<Feature>&& features,
     bool has_subspecies
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       features(std::move(features)), subspecies(has_subspecies) {}
 

--- a/src/core/models/species/species.cpp
+++ b/src/core/models/species/species.cpp
@@ -29,7 +29,7 @@ CreateResult<Species> Species::create_for(Data&& data, const Content& content) {
             auto [_, sub_errors] = feature_result.data_and_errors();
             return InvalidCreate<Species>(std::move(data), std::move(sub_errors));
         }
-        features.emplace_back(feature_result.value());
+        features.push_back(feature_result.value());
     }
     return ValidCreate(Species(
         std::move(data.name), std::move(data.description), std::move(data.source_path), std::move(features),

--- a/src/core/models/species/species.hpp
+++ b/src/core/models/species/species.hpp
@@ -29,18 +29,18 @@ public:
     Species(Species&&) = default;
     Species& operator=(Species&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::vector<Feature>& get_features() const noexcept;
-    bool has_subspecies() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::vector<Feature>& get_features() const;
+    bool has_subspecies() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
     Species(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::vector<Feature>&& features, bool has_subspecies
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -50,7 +50,7 @@ private:
 };
 
 struct Species::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::vector<Feature::Data> features_data;
     bool subspecies;

--- a/src/core/models/species/species.hpp
+++ b/src/core/models/species/species.hpp
@@ -26,8 +26,8 @@ public:
 
     Species(const Species&) = delete;
     Species& operator=(const Species&) = delete;
-    Species(Species&&) = default;
-    Species& operator=(Species&&) = default;
+    Species(Species&&) noexcept = default;
+    Species& operator=(Species&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/spell/spell.cpp
+++ b/src/core/models/spell/spell.cpp
@@ -44,23 +44,23 @@ CreateResult<Spell> Spell::create(Data&& data) {
     ));
 }
 
-const std::string& Spell::get_name() const noexcept { return name; }
+const std::string& Spell::get_name() const { return name; }
 
-const std::string& Spell::get_description() const noexcept { return description; }
+const std::string& Spell::get_description() const { return description; }
 
-const SourceInfo& Spell::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Spell::get_source_info() const { return source_info; }
 
-const SpellComponents& Spell::get_components() const noexcept { return components; }
+const SpellComponents& Spell::get_components() const { return components; }
 
-const SpellType& Spell::get_type() const noexcept { return type; }
+const SpellType& Spell::get_type() const { return type; }
 
-const std::string& Spell::get_casting_time() const noexcept { return casting_time; }
+const std::string& Spell::get_casting_time() const { return casting_time; }
 
-const std::string& Spell::get_range() const noexcept { return range; }
+const std::string& Spell::get_range() const { return range; }
 
-const std::string& Spell::get_duration() const noexcept { return duration; }
+const std::string& Spell::get_duration() const { return duration; }
 
-const std::set<std::string>& Spell::get_classes() const noexcept { return classes; }
+const std::set<std::string>& Spell::get_classes() const { return classes; }
 
 void Spell::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
@@ -68,7 +68,7 @@ Spell::Spell(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, SpellComponents&& components,
     SpellType&& type, std::string&& casting_time, std::string&& range, std::string&& duration,
     std::set<std::string>&& classes
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       components(std::move(components)), type(std::move(type)), casting_time(std::move(casting_time)),
       range(std::move(range)), duration(std::move(duration)), classes(std::move(classes)) {}

--- a/src/core/models/spell/spell.hpp
+++ b/src/core/models/spell/spell.hpp
@@ -23,15 +23,15 @@ public:
 
     static CreateResult<Spell> create(Data&& spell_data);
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const SpellComponents& get_components() const noexcept;
-    const SpellType& get_type() const noexcept;
-    const std::string& get_casting_time() const noexcept;
-    const std::string& get_range() const noexcept;
-    const std::string& get_duration() const noexcept;
-    const std::set<std::string>& get_classes() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const SpellComponents& get_components() const;
+    const SpellType& get_type() const;
+    const std::string& get_casting_time() const;
+    const std::string& get_range() const;
+    const std::string& get_duration() const;
+    const std::set<std::string>& get_classes() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
@@ -39,7 +39,7 @@ private:
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         SpellComponents&& components, SpellType&& type, std::string&& casting_time, std::string&& range,
         std::string&& duration, std::set<std::string>&& classes
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -53,7 +53,7 @@ private:
 };
 
 struct Spell::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     SpellComponents::Data components_data;
     SpellType::Data type_data;

--- a/src/core/models/spell/spell_components.cpp
+++ b/src/core/models/spell/spell_components.cpp
@@ -52,19 +52,19 @@ CreateResult<SpellComponents> SpellComponents::create(Data&& data) {
 
 SpellComponents::SpellComponents(
     bool verbal, bool somatic, bool material, const std::string& material_components
-) noexcept
+)
     : verbal(verbal), somatic(somatic), material(material), material_components(material_components) {}
 
-SpellComponents::SpellComponents(bool verbal, bool somatic, bool material, std::string&& material_components) noexcept
+SpellComponents::SpellComponents(bool verbal, bool somatic, bool material, std::string&& material_components)
     : verbal(verbal), somatic(somatic), material(material), material_components(std::move(material_components)) {}
 
-bool SpellComponents::has_verbal() const noexcept { return verbal; }
+bool SpellComponents::has_verbal() const { return verbal; }
 
-bool SpellComponents::has_somatic() const noexcept { return somatic; }
+bool SpellComponents::has_somatic() const { return somatic; }
 
-bool SpellComponents::has_material() const noexcept { return material; }
+bool SpellComponents::has_material() const { return material; }
 
-const std::string& SpellComponents::get_material_components() const noexcept { return material_components; }
+const std::string& SpellComponents::get_material_components() const { return material_components; }
 
 std::string SpellComponents::str() const {
     if (!material || material_components.empty()) {

--- a/src/core/models/spell/spell_components.cpp
+++ b/src/core/models/spell/spell_components.cpp
@@ -50,9 +50,7 @@ CreateResult<SpellComponents> SpellComponents::create(Data&& data) {
     return ValidCreate(SpellComponents(verbal, somatic, material, std::move(materials_needed)));
 }
 
-SpellComponents::SpellComponents(
-    bool verbal, bool somatic, bool material, const std::string& material_components
-)
+SpellComponents::SpellComponents(bool verbal, bool somatic, bool material, const std::string& material_components)
     : verbal(verbal), somatic(somatic), material(material), material_components(material_components) {}
 
 SpellComponents::SpellComponents(bool verbal, bool somatic, bool material, std::string&& material_components)

--- a/src/core/models/spell/spell_components.hpp
+++ b/src/core/models/spell/spell_components.hpp
@@ -16,13 +16,13 @@ public:
 
     static CreateResult<SpellComponents> create(Data&& components_data);
 
-    SpellComponents(bool verbal, bool somatic, bool material, const std::string& material_components = "") noexcept;
-    SpellComponents(bool verbal, bool somatic, bool material, std::string&& material_components = "") noexcept;
+    SpellComponents(bool verbal, bool somatic, bool material, const std::string& material_components = "");
+    SpellComponents(bool verbal, bool somatic, bool material, std::string&& material_components = "");
 
-    bool has_verbal() const noexcept;
-    bool has_somatic() const noexcept;
-    bool has_material() const noexcept;
-    const std::string& get_material_components() const noexcept;
+    bool has_verbal() const;
+    bool has_somatic() const;
+    bool has_material() const;
+    const std::string& get_material_components() const;
 
     // returns a string representation of spell components "V, M (a pinch of salt)"
     std::string str() const;
@@ -36,7 +36,7 @@ private:
 };
 
 struct SpellComponents::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string str;
 };

--- a/src/core/models/spell/spell_type.cpp
+++ b/src/core/models/spell/spell_type.cpp
@@ -55,14 +55,14 @@ CreateResult<SpellType> SpellType::create(Data&& data) {
     return ValidCreate(SpellType(level, magic_school, is_ritual));
 }
 
-SpellType::SpellType(SpellLevel spell_level, MagicSchool magic_school, bool is_ritual) noexcept
+SpellType::SpellType(SpellLevel spell_level, MagicSchool magic_school, bool is_ritual)
     : spell_level(spell_level), magic_school(magic_school), ritual(is_ritual) {}
 
-SpellLevel SpellType::get_spell_level() const noexcept { return spell_level; }
+SpellLevel SpellType::get_spell_level() const { return spell_level; }
 
-MagicSchool SpellType::get_magic_school() const noexcept { return magic_school; }
+MagicSchool SpellType::get_magic_school() const { return magic_school; }
 
-bool SpellType::is_ritual() const noexcept { return ritual; }
+bool SpellType::is_ritual() const { return ritual; }
 
 int SpellType::get_spell_level_as_int() const { return static_cast<int>(spell_level); }
 

--- a/src/core/models/spell/spell_type.hpp
+++ b/src/core/models/spell/spell_type.hpp
@@ -31,11 +31,11 @@ public:
 
     static CreateResult<SpellType> create(Data&& type_data);
 
-    SpellType(SpellLevel spell_level, MagicSchool magic_school, bool is_ritual) noexcept;
+    SpellType(SpellLevel spell_level, MagicSchool magic_school, bool is_ritual);
 
-    SpellLevel get_spell_level() const noexcept;
-    MagicSchool get_magic_school() const noexcept;
-    bool is_ritual() const noexcept;
+    SpellLevel get_spell_level() const;
+    MagicSchool get_magic_school() const;
+    bool is_ritual() const;
 
     int get_spell_level_as_int() const;
     std::string_view get_magic_school_name() const;
@@ -51,7 +51,7 @@ private:
 };
 
 struct SpellType::Data {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     std::string str;
 };

--- a/src/core/models/spellcasting/preparation_spellcasting.cpp
+++ b/src/core/models/spellcasting/preparation_spellcasting.cpp
@@ -11,9 +11,9 @@
 
 namespace dnd {
 
-PreparationSpellcastingType PreparationSpellcasting::get_type() const noexcept { return type; }
+PreparationSpellcastingType PreparationSpellcasting::get_type() const { return type; }
 
-int PreparationSpellcasting::get_prepared_spells_amount(AbilityScores ability_scores, int level) const noexcept {
+int PreparationSpellcasting::get_prepared_spells_amount(AbilityScores ability_scores, int level) const {
     if (level < 1 || level > 20) {
         return 0;
     }
@@ -35,7 +35,7 @@ int PreparationSpellcasting::get_prepared_spells_amount(AbilityScores ability_sc
 PreparationSpellcasting::PreparationSpellcasting(
     Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
     std::array<std::array<int, 20>, 9>&& spell_slots, PreparationSpellcastingType type
-) noexcept
+)
     : Spellcasting(spellcasting_ability, ritual_casting, std::move(cantrips_known), std::move(spell_slots)),
       type(type) {}
 

--- a/src/core/models/spellcasting/preparation_spellcasting.hpp
+++ b/src/core/models/spellcasting/preparation_spellcasting.hpp
@@ -22,10 +22,10 @@ public:
     PreparationSpellcasting(
         Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
         std::array<std::array<int, 20>, 9>&& spell_slots, PreparationSpellcastingType type
-    ) noexcept;
+    );
 
-    PreparationSpellcastingType get_type() const noexcept;
-    int get_prepared_spells_amount(AbilityScores ability_scores, int level) const noexcept;
+    PreparationSpellcastingType get_type() const;
+    int get_prepared_spells_amount(AbilityScores ability_scores, int level) const;
 private:
     PreparationSpellcastingType type;
 };

--- a/src/core/models/spellcasting/spellcasting.cpp
+++ b/src/core/models/spellcasting/spellcasting.cpp
@@ -9,9 +9,9 @@
 
 namespace dnd {
 
-Ability Spellcasting::get_ability() const noexcept { return ability; }
+Ability Spellcasting::get_ability() const { return ability; }
 
-bool Spellcasting::allows_ritual_casting() const noexcept { return ritual_casting; }
+bool Spellcasting::allows_ritual_casting() const { return ritual_casting; }
 
 int Spellcasting::get_cantrips_known(int class_level) const {
     if (class_level < 1 || class_level > 20) {
@@ -30,7 +30,7 @@ int Spellcasting::get_spell_slots(int spell_slot_level, int class_level) const {
 Spellcasting::Spellcasting(
     Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
     std::array<std::array<int, 20>, 9>&& spell_slots
-) noexcept
+)
     : ability(spellcasting_ability), ritual_casting(ritual_casting), cantrips_known(std::move(cantrips_known)),
       spell_slots(std::move(spell_slots)) {}
 

--- a/src/core/models/spellcasting/spellcasting.hpp
+++ b/src/core/models/spellcasting/spellcasting.hpp
@@ -14,10 +14,10 @@ class Spellcasting {
 public:
     struct Data;
 
-    virtual ~Spellcasting() noexcept = default;
+    virtual ~Spellcasting() = default;
 
-    Ability get_ability() const noexcept;
-    bool allows_ritual_casting() const noexcept;
+    Ability get_ability() const;
+    bool allows_ritual_casting() const;
 
     int get_cantrips_known(int class_level) const;
     int get_spell_slots(int spell_slot_level, int class_level) const;
@@ -25,7 +25,7 @@ protected:
     Spellcasting(
         Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
         std::array<std::array<int, 20>, 9>&& spell_slots
-    ) noexcept;
+    );
 private:
     Ability ability;
     bool ritual_casting;
@@ -34,8 +34,8 @@ private:
 };
 
 struct Spellcasting::Data {
-    explicit Data() noexcept;
-    std::strong_ordering operator<=>(const Spellcasting::Data&) const noexcept = default;
+    explicit Data();
+    std::strong_ordering operator<=>(const Spellcasting::Data&) const = default;
 
     bool is_spellcaster;
     std::string ability;
@@ -47,7 +47,7 @@ struct Spellcasting::Data {
     std::array<std::array<int, 20>, 9> spell_slots;
 };
 
-inline Spellcasting::Data::Data() noexcept {
+inline Spellcasting::Data::Data() {
     spells_known.fill(0);
     cantrips_known.fill(0);
     for (std::array<int, 20>& arr : spell_slots) {

--- a/src/core/models/spellcasting/spells_known_spellcasting.cpp
+++ b/src/core/models/spellcasting/spells_known_spellcasting.cpp
@@ -10,7 +10,7 @@
 
 namespace dnd {
 
-int SpellsKnownSpellcasting::get_spells_known(int level) const noexcept {
+int SpellsKnownSpellcasting::get_spells_known(int level) const {
     if (level < 1 || level > 20) {
         return 0;
     }
@@ -20,7 +20,7 @@ int SpellsKnownSpellcasting::get_spells_known(int level) const noexcept {
 SpellsKnownSpellcasting::SpellsKnownSpellcasting(
     Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
     std::array<std::array<int, 20>, 9>&& spell_slots, std::array<int, 20>&& spells_known
-) noexcept
+)
     : Spellcasting(spellcasting_ability, ritual_casting, std::move(cantrips_known), std::move(spell_slots)),
       spells_known(std::move(spells_known)) {}
 

--- a/src/core/models/spellcasting/spells_known_spellcasting.hpp
+++ b/src/core/models/spellcasting/spells_known_spellcasting.hpp
@@ -15,9 +15,9 @@ public:
     SpellsKnownSpellcasting(
         Ability spellcasting_ability, bool ritual_casting, std::array<int, 20>&& cantrips_known,
         std::array<std::array<int, 20>, 9>&& spell_slots, std::array<int, 20>&& spells_known
-    ) noexcept;
+    );
 
-    int get_spells_known(int level) const noexcept;
+    int get_spells_known(int level) const;
 private:
     std::array<int, 20> spells_known;
 };

--- a/src/core/models/subclass/subclass.cpp
+++ b/src/core/models/subclass/subclass.cpp
@@ -33,7 +33,7 @@ CreateResult<Subclass> Subclass::create_for(Data&& data, const Content& content)
             auto [_, sub_errors] = feature_result.data_and_errors();
             return InvalidCreate<Subclass>(std::move(data), std::move(sub_errors));
         }
-        features.emplace_back(feature_result.value());
+        features.push_back(feature_result.value());
     }
     CRef<Class> cls = content.get_classes().get(data.class_name).value();
 

--- a/src/core/models/subclass/subclass.cpp
+++ b/src/core/models/subclass/subclass.cpp
@@ -50,26 +50,26 @@ CreateResult<Subclass> Subclass::create_for(Data&& data, const Content& content)
     ));
 }
 
-const std::string& Subclass::get_name() const noexcept { return name; }
+const std::string& Subclass::get_name() const { return name; }
 
-const std::string& Subclass::get_description() const noexcept { return description; }
+const std::string& Subclass::get_description() const { return description; }
 
-const SourceInfo& Subclass::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Subclass::get_source_info() const { return source_info; }
 
-const std::vector<ClassFeature>& Subclass::get_features() const noexcept { return features; }
+const std::vector<ClassFeature>& Subclass::get_features() const { return features; }
 
-bool Subclass::has_spellcasting() const noexcept { return spellcasting != nullptr; }
+bool Subclass::has_spellcasting() const { return spellcasting != nullptr; }
 
-const Spellcasting* Subclass::get_spellcasting() const noexcept { return spellcasting.get(); }
+const Spellcasting* Subclass::get_spellcasting() const { return spellcasting.get(); }
 
-CRef<Class> Subclass::get_class() const noexcept { return cls; }
+CRef<Class> Subclass::get_class() const { return cls; }
 
 void Subclass::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Subclass::Subclass(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path,
     std::vector<ClassFeature>&& features, CRef<Class> cls, std::unique_ptr<Spellcasting>&& spellcasting
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       features(std::move(features)), cls(cls), spellcasting(std::move(spellcasting)) {}
 

--- a/src/core/models/subclass/subclass.hpp
+++ b/src/core/models/subclass/subclass.hpp
@@ -32,20 +32,20 @@ public:
     Subclass(Subclass&&) = default;
     Subclass& operator=(Subclass&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::vector<ClassFeature>& get_features() const noexcept;
-    bool has_spellcasting() const noexcept;
-    const Spellcasting* get_spellcasting() const noexcept;
-    CRef<Class> get_class() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::vector<ClassFeature>& get_features() const;
+    bool has_spellcasting() const;
+    const Spellcasting* get_spellcasting() const;
+    CRef<Class> get_class() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
     Subclass(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::vector<ClassFeature>&& features, CRef<Class> cls, std::unique_ptr<Spellcasting>&& spellcasting = nullptr
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -56,7 +56,7 @@ private:
 };
 
 struct Subclass::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Data&) const = default;
 
     Spellcasting::Data spellcasting_data;
     std::vector<ClassFeature::Data> features_data;

--- a/src/core/models/subclass/subclass.hpp
+++ b/src/core/models/subclass/subclass.hpp
@@ -29,8 +29,8 @@ public:
 
     Subclass(const Subclass&) = delete;
     Subclass& operator=(const Subclass&) = delete;
-    Subclass(Subclass&&) = default;
-    Subclass& operator=(Subclass&&) = default;
+    Subclass(Subclass&&) noexcept = default;
+    Subclass& operator=(Subclass&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/models/subspecies/subspecies.cpp
+++ b/src/core/models/subspecies/subspecies.cpp
@@ -32,7 +32,7 @@ CreateResult<Subspecies> Subspecies::create_for(Data&& data, const Content& cont
             auto [_, sub_errors] = feature_result.data_and_errors();
             return InvalidCreate<Subspecies>(std::move(data), std::move(sub_errors));
         }
-        features.emplace_back(feature_result.value());
+        features.push_back(feature_result.value());
     }
     CRef<Species> species = content.get_species().get(data.species_name).value();
     return ValidCreate(Subspecies(

--- a/src/core/models/subspecies/subspecies.cpp
+++ b/src/core/models/subspecies/subspecies.cpp
@@ -40,22 +40,22 @@ CreateResult<Subspecies> Subspecies::create_for(Data&& data, const Content& cont
     ));
 }
 
-const std::string& Subspecies::get_name() const noexcept { return name; }
+const std::string& Subspecies::get_name() const { return name; }
 
-const std::string& Subspecies::get_description() const noexcept { return description; }
+const std::string& Subspecies::get_description() const { return description; }
 
-const SourceInfo& Subspecies::get_source_info() const noexcept { return source_info; }
+const SourceInfo& Subspecies::get_source_info() const { return source_info; }
 
-const std::vector<Feature>& Subspecies::get_features() const noexcept { return features; }
+const std::vector<Feature>& Subspecies::get_features() const { return features; }
 
-CRef<Species> Subspecies::get_species() const noexcept { return species; }
+CRef<Species> Subspecies::get_species() const { return species; }
 
 void Subspecies::accept_visitor(ContentVisitor& visitor) const { visitor(*this); }
 
 Subspecies::Subspecies(
     std::string&& name, std::string&& description, std::filesystem::path&& source_path, std::vector<Feature>&& features,
     CRef<Species> species
-) noexcept
+)
     : name(std::move(name)), description(std::move(description)), source_info(std::move(source_path)),
       features(std::move(features)), species(species) {}
 

--- a/src/core/models/subspecies/subspecies.hpp
+++ b/src/core/models/subspecies/subspecies.hpp
@@ -31,18 +31,18 @@ public:
     Subspecies(Subspecies&&) = default;
     Subspecies& operator=(Subspecies&&) = default;
 
-    const std::string& get_name() const noexcept override;
-    const std::string& get_description() const noexcept override;
-    const SourceInfo& get_source_info() const noexcept override;
-    const std::vector<Feature>& get_features() const noexcept;
-    CRef<Species> get_species() const noexcept;
+    const std::string& get_name() const override;
+    const std::string& get_description() const override;
+    const SourceInfo& get_source_info() const override;
+    const std::vector<Feature>& get_features() const;
+    CRef<Species> get_species() const;
 
     virtual void accept_visitor(ContentVisitor& visitor) const override final;
 private:
     Subspecies(
         std::string&& name, std::string&& description, std::filesystem::path&& source_path,
         std::vector<Feature>&& features, CRef<Species> species
-    ) noexcept;
+    );
 
     std::string name;
     std::string description;
@@ -52,7 +52,7 @@ private:
 };
 
 struct Subspecies::Data : public ValidationData {
-    std::strong_ordering operator<=>(const Subspecies::Data&) const noexcept = default;
+    std::strong_ordering operator<=>(const Subspecies::Data&) const = default;
 
     std::vector<Feature::Data> features_data;
     std::string species_name;

--- a/src/core/models/subspecies/subspecies.hpp
+++ b/src/core/models/subspecies/subspecies.hpp
@@ -28,8 +28,8 @@ public:
 
     Subspecies(const Subspecies&) = delete;
     Subspecies& operator=(const Subspecies&) = delete;
-    Subspecies(Subspecies&&) = default;
-    Subspecies& operator=(Subspecies&&) = default;
+    Subspecies(Subspecies&&) noexcept = default;
+    Subspecies& operator=(Subspecies&&) noexcept = default;
 
     const std::string& get_name() const override;
     const std::string& get_description() const override;

--- a/src/core/output/latex_builder/latex_scope.cpp
+++ b/src/core/output/latex_builder/latex_scope.cpp
@@ -33,21 +33,21 @@ LatexScope* LatexScope::add_line_break(const std::string& spacing_argument) {
 LatexScope* LatexScope::add_scope() {
     auto new_scope = std::make_unique<LatexScope>();
     LatexScope* ptr = new_scope.get();
-    objects.emplace_back(std::move(new_scope));
+    objects.push_back(std::move(new_scope));
     return ptr;
 }
 
 LatexText* LatexScope::add_text(const std::string& text) {
     auto new_text = std::make_unique<LatexText>(text);
     LatexText* ptr = new_text.get();
-    objects.emplace_back(std::move(new_text));
+    objects.push_back(std::move(new_text));
     return ptr;
 }
 
 LatexCommand* LatexScope::add_command(const std::string& name) {
     auto new_command = std::make_unique<LatexCommand>(name);
     LatexCommand* ptr = new_command.get();
-    objects.emplace_back(std::move(new_command));
+    objects.push_back(std::move(new_command));
     return ptr;
 }
 
@@ -58,15 +58,15 @@ LatexCommand* LatexScope::add_command(const std::string& name, const std::string
 LatexBeginEnd LatexScope::add_begin_end(const std::string& name) {
     auto begin_command = std::make_unique<LatexCommand>("begin{" + name + '}');
     LatexCommand* begin_ptr = begin_command.get();
-    objects.emplace_back(std::move(begin_command));
+    objects.push_back(std::move(begin_command));
 
     auto begin_end_scope = std::make_unique<LatexScope>();
     begin_end_scope->no_enclosing_braces();
     LatexScope* scope_ptr = begin_end_scope.get();
-    objects.emplace_back(std::move(begin_end_scope));
+    objects.push_back(std::move(begin_end_scope));
 
     auto end_command = std::make_unique<LatexCommand>("end{" + name + '}');
-    objects.emplace_back(std::move(end_command));
+    objects.push_back(std::move(end_command));
 
     return LatexBeginEnd{begin_ptr, scope_ptr};
 }

--- a/src/core/output/string_formatting/formats/bulleted_list.cpp
+++ b/src/core/output/string_formatting/formats/bulleted_list.cpp
@@ -9,11 +9,11 @@
 
 namespace dnd {
 
-BulletedList::BulletedList() noexcept : items({}) {}
+BulletedList::BulletedList() : items({}) {}
 
 void BulletedList::add_item(std::string_view item) { items.push_back(item); }
 
-std::vector<std::string_view> BulletedList::get_items() const noexcept { return items; }
+std::vector<std::string_view> BulletedList::get_items() const { return items; }
 
 void BulletedList::accept(const FormatVisitor& visitor) const { visitor(*this); }
 

--- a/src/core/output/string_formatting/formats/bulleted_list.hpp
+++ b/src/core/output/string_formatting/formats/bulleted_list.hpp
@@ -12,9 +12,9 @@ namespace dnd {
 
 class BulletedList : public Format {
 public:
-    explicit BulletedList() noexcept;
+    explicit BulletedList();
     void add_item(std::string_view item);
-    std::vector<std::string_view> get_items() const noexcept;
+    std::vector<std::string_view> get_items() const;
     virtual void accept(const FormatVisitor& visitor) const override;
 private:
     std::vector<std::string_view> items;

--- a/src/core/output/string_formatting/formats/paragraph.cpp
+++ b/src/core/output/string_formatting/formats/paragraph.cpp
@@ -8,8 +8,7 @@
 
 namespace dnd {
 
-Paragraph::Paragraph(std::string_view text, bool empty_line_after)
-    : text(text), empty_line_after(empty_line_after) {}
+Paragraph::Paragraph(std::string_view text, bool empty_line_after) : text(text), empty_line_after(empty_line_after) {}
 
 std::string_view Paragraph::get_text() const { return text; }
 

--- a/src/core/output/string_formatting/formats/paragraph.cpp
+++ b/src/core/output/string_formatting/formats/paragraph.cpp
@@ -8,12 +8,12 @@
 
 namespace dnd {
 
-Paragraph::Paragraph(std::string_view text, bool empty_line_after) noexcept
+Paragraph::Paragraph(std::string_view text, bool empty_line_after)
     : text(text), empty_line_after(empty_line_after) {}
 
-std::string_view Paragraph::get_text() const noexcept { return text; }
+std::string_view Paragraph::get_text() const { return text; }
 
-bool Paragraph::get_empty_line_after() const noexcept { return empty_line_after; }
+bool Paragraph::get_empty_line_after() const { return empty_line_after; }
 
 void Paragraph::accept(const FormatVisitor& visitor) const { visitor(*this); }
 

--- a/src/core/output/string_formatting/formats/paragraph.hpp
+++ b/src/core/output/string_formatting/formats/paragraph.hpp
@@ -17,9 +17,9 @@ public:
      * @param text the text of the paragraph
      * @param empty_line_after whether to add an empty line after the paragraph
      */
-    explicit Paragraph(std::string_view text, bool empty_line_after = false) noexcept;
-    std::string_view get_text() const noexcept;
-    bool get_empty_line_after() const noexcept;
+    explicit Paragraph(std::string_view text, bool empty_line_after = false);
+    std::string_view get_text() const;
+    bool get_empty_line_after() const;
     virtual void accept(const FormatVisitor& visitor) const override;
 private:
     std::string_view text;

--- a/src/core/output/string_formatting/formats/table.cpp
+++ b/src/core/output/string_formatting/formats/table.cpp
@@ -9,11 +9,11 @@
 
 namespace dnd {
 
-Table::Table() noexcept : num_columns(0), current_row(0), rows({{}}) {}
+Table::Table() : num_columns(0), current_row(0), rows({{}}) {}
 
-std::vector<std::vector<std::string_view>> Table::get_rows() const noexcept { return rows; }
+std::vector<std::vector<std::string_view>> Table::get_rows() const { return rows; }
 
-size_t Table::get_num_columns() const noexcept { return num_columns; }
+size_t Table::get_num_columns() const { return num_columns; }
 
 void Table::add_element(std::string_view element) {
     rows[current_row].push_back(element);

--- a/src/core/output/string_formatting/formats/table.hpp
+++ b/src/core/output/string_formatting/formats/table.hpp
@@ -13,7 +13,7 @@ namespace dnd {
 
 class Table : public Format {
 public:
-    explicit Table() noexcept;
+    explicit Table();
     /**
      * @brief Accept a format visitor
      * @param visitor a pointer to the format visitor
@@ -21,8 +21,8 @@ public:
     virtual void accept(const FormatVisitor& visitor) const override;
     void add_element(std::string_view element);
     void next_row();
-    std::vector<std::vector<std::string_view>> get_rows() const noexcept;
-    size_t get_num_columns() const noexcept;
+    std::vector<std::vector<std::string_view>> get_rows() const;
+    size_t get_num_columns() const;
 private:
     size_t num_columns;
     size_t current_row;

--- a/src/core/output/string_formatting/string_formatter.cpp
+++ b/src/core/output/string_formatting/string_formatter.cpp
@@ -24,7 +24,7 @@ std::vector<std::unique_ptr<Format>> StringFormatter::parse_formats(const std::s
     while (it != text.end()) {
         // iterator is at the start of a new line
         if (*it == '-') {
-            formats.emplace_back(parse_bulleted_list(it, text.cend()));
+            formats.push_back(parse_bulleted_list(it, text.cend()));
         } else {
             std::string::const_iterator test_it = it;
             bool is_table = false;
@@ -36,9 +36,9 @@ std::vector<std::unique_ptr<Format>> StringFormatter::parse_formats(const std::s
                 ++test_it;
             }
             if (is_table) {
-                formats.emplace_back(parse_table(it, text.cend()));
+                formats.push_back(parse_table(it, text.cend()));
             } else {
-                formats.emplace_back(parse_paragraph(it, text.cend()));
+                formats.push_back(parse_paragraph(it, text.cend()));
             }
         }
         if (it == text.end()) {

--- a/src/core/output/string_formatting/string_formatter.cpp
+++ b/src/core/output/string_formatting/string_formatter.cpp
@@ -14,7 +14,7 @@
 
 namespace dnd {
 
-StringFormatter::StringFormatter(bool ignore_double_newline) noexcept : ignore_double_newline(ignore_double_newline) {}
+StringFormatter::StringFormatter(bool ignore_double_newline) : ignore_double_newline(ignore_double_newline) {}
 
 std::vector<std::unique_ptr<Format>> StringFormatter::parse_formats(const std::string& text) const {
     std::vector<std::unique_ptr<Format>> formats;

--- a/src/core/output/string_formatting/string_formatter.hpp
+++ b/src/core/output/string_formatting/string_formatter.hpp
@@ -20,7 +20,7 @@ public:
      * @brief Initialize a new string formatter
      * @param ignore_double_newline whether to ignore double newlines and just treat them as one newline character
      */
-    explicit StringFormatter(bool ignore_double_newline = false) noexcept;
+    explicit StringFormatter(bool ignore_double_newline = false);
     /**
      * @brief Parse the given text into a vector of formats
      * @param text the text to find the formats in

--- a/src/core/parsing/character/character_parser.cpp
+++ b/src/core/parsing/character/character_parser.cpp
@@ -21,7 +21,7 @@
 
 namespace dnd {
 
-CharacterParser::CharacterParser(const std::filesystem::path& filepath) noexcept
+CharacterParser::CharacterParser(const std::filesystem::path& filepath)
     : FileParser(filepath, false), feature_parser(filepath) {}
 
 Errors CharacterParser::parse() {

--- a/src/core/parsing/character/character_parser.hpp
+++ b/src/core/parsing/character/character_parser.hpp
@@ -17,7 +17,7 @@ namespace dnd {
 
 class CharacterParser : public FileParser {
 public:
-    explicit CharacterParser(const std::filesystem::path& filepath) noexcept;
+    explicit CharacterParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void set_context(const Content& content) override;
     virtual void save_result(Content& content) override;

--- a/src/core/parsing/class/class_parser.cpp
+++ b/src/core/parsing/class/class_parser.cpp
@@ -19,7 +19,7 @@
 
 namespace dnd {
 
-ClassParser::ClassParser(const std::filesystem::path& filepath) noexcept
+ClassParser::ClassParser(const std::filesystem::path& filepath)
     : FileParser(filepath, false), class_feature_parser(filepath), data() {}
 
 Errors ClassParser::parse() {

--- a/src/core/parsing/class/class_parser.hpp
+++ b/src/core/parsing/class/class_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class ClassParser : public FileParser {
 public:
-    explicit ClassParser(const std::filesystem::path& filepath) noexcept;
+    explicit ClassParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void save_result(Content& content) override;
 private:

--- a/src/core/parsing/content_parsing.cpp
+++ b/src/core/parsing/content_parsing.cpp
@@ -88,7 +88,7 @@ ParsingResult parse_content(const std::filesystem::path& content_path, const std
     std::vector<std::filesystem::directory_entry> content_directories;
     for (const auto& entry : std::filesystem::directory_iterator(content_path / "general")) {
         if (entry.is_directory()) {
-            content_directories.emplace_back(std::move(entry));
+            content_directories.push_back(std::move(entry));
         }
     }
     content_directories.emplace_back(content_path / campaign_dir_name);

--- a/src/core/parsing/content_parsing.hpp
+++ b/src/core/parsing/content_parsing.hpp
@@ -15,8 +15,8 @@ struct ParsingResult {
     ParsingResult() = default;
     ParsingResult(const ParsingResult&) = delete;
     ParsingResult& operator=(const ParsingResult&) = delete;
-    ParsingResult(ParsingResult&&) = default;
-    ParsingResult& operator=(ParsingResult&&) = default;
+    ParsingResult(ParsingResult&&) noexcept = default;
+    ParsingResult& operator=(ParsingResult&&) noexcept = default;
 
     Content content;
     Errors errors;

--- a/src/core/parsing/effects/effects_parser.cpp
+++ b/src/core/parsing/effects/effects_parser.cpp
@@ -31,7 +31,7 @@
 
 namespace dnd {
 
-EffectsParser::EffectsParser(const std::filesystem::path& filepath) noexcept : Parser(filepath) {}
+EffectsParser::EffectsParser(const std::filesystem::path& filepath) : Parser(filepath) {}
 
 Errors EffectsParser::parse_into(nlohmann::ordered_json&& json, Effects::Data& data) const {
     Errors errors;

--- a/src/core/parsing/effects/effects_parser.hpp
+++ b/src/core/parsing/effects/effects_parser.hpp
@@ -22,7 +22,7 @@ namespace dnd {
 
 class EffectsParser : public Parser {
 public:
-    explicit EffectsParser(const std::filesystem::path& filepath) noexcept;
+    explicit EffectsParser(const std::filesystem::path& filepath);
     Errors parse_into(nlohmann::ordered_json&& json, Effects::Data& data) const;
 private:
     Errors parse_activation_conditions_into(nlohmann::ordered_json& json, std::vector<Condition::Data>& data) const;

--- a/src/core/parsing/effects_provider/choosable_parser.cpp
+++ b/src/core/parsing/effects_provider/choosable_parser.cpp
@@ -17,7 +17,7 @@
 
 namespace dnd {
 
-ChoosableParser::ChoosableParser(const std::filesystem::path& filepath) noexcept
+ChoosableParser::ChoosableParser(const std::filesystem::path& filepath)
     : Parser(filepath), feature_parser(filepath) {}
 
 Errors ChoosableParser::parse_into(nlohmann::ordered_json&& json, Choosable::Data& data) const {

--- a/src/core/parsing/effects_provider/choosable_parser.cpp
+++ b/src/core/parsing/effects_provider/choosable_parser.cpp
@@ -17,8 +17,7 @@
 
 namespace dnd {
 
-ChoosableParser::ChoosableParser(const std::filesystem::path& filepath)
-    : Parser(filepath), feature_parser(filepath) {}
+ChoosableParser::ChoosableParser(const std::filesystem::path& filepath) : Parser(filepath), feature_parser(filepath) {}
 
 Errors ChoosableParser::parse_into(nlohmann::ordered_json&& json, Choosable::Data& data) const {
     Errors errors;

--- a/src/core/parsing/effects_provider/choosable_parser.hpp
+++ b/src/core/parsing/effects_provider/choosable_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class ChoosableParser : public Parser {
 public:
-    explicit ChoosableParser(const std::filesystem::path& filepath) noexcept;
+    explicit ChoosableParser(const std::filesystem::path& filepath);
     Errors parse_into(nlohmann::ordered_json&& json, Choosable::Data& data) const;
 private:
     FeatureParser feature_parser;

--- a/src/core/parsing/effects_provider/class_feature_parser.cpp
+++ b/src/core/parsing/effects_provider/class_feature_parser.cpp
@@ -15,7 +15,7 @@
 
 namespace dnd {
 
-ClassFeatureParser::ClassFeatureParser(const std::filesystem::path& filepath) noexcept
+ClassFeatureParser::ClassFeatureParser(const std::filesystem::path& filepath)
     : Parser(filepath), effects_parser(filepath) {}
 
 Errors ClassFeatureParser::parse_into(nlohmann::ordered_json&& json, ClassFeature::Data& data) const {

--- a/src/core/parsing/effects_provider/class_feature_parser.hpp
+++ b/src/core/parsing/effects_provider/class_feature_parser.hpp
@@ -17,7 +17,7 @@ namespace dnd {
 
 class ClassFeatureParser : public Parser {
 public:
-    explicit ClassFeatureParser(const std::filesystem::path& filepath) noexcept;
+    explicit ClassFeatureParser(const std::filesystem::path& filepath);
     Errors parse_into(nlohmann::ordered_json&& json, ClassFeature::Data& data) const;
     Errors parse_multiple_into(nlohmann::ordered_json&& json, std::vector<ClassFeature::Data>& data) const;
 private:

--- a/src/core/parsing/effects_provider/feature_parser.cpp
+++ b/src/core/parsing/effects_provider/feature_parser.cpp
@@ -16,7 +16,7 @@
 
 namespace dnd {
 
-FeatureParser::FeatureParser(const std::filesystem::path& filepath) noexcept
+FeatureParser::FeatureParser(const std::filesystem::path& filepath)
     : Parser(filepath), effects_parser(filepath) {}
 
 Errors FeatureParser::parse_into(nlohmann::ordered_json&& json, Feature::Data& data) const {

--- a/src/core/parsing/effects_provider/feature_parser.cpp
+++ b/src/core/parsing/effects_provider/feature_parser.cpp
@@ -16,8 +16,7 @@
 
 namespace dnd {
 
-FeatureParser::FeatureParser(const std::filesystem::path& filepath)
-    : Parser(filepath), effects_parser(filepath) {}
+FeatureParser::FeatureParser(const std::filesystem::path& filepath) : Parser(filepath), effects_parser(filepath) {}
 
 Errors FeatureParser::parse_into(nlohmann::ordered_json&& json, Feature::Data& data) const {
     Errors errors;

--- a/src/core/parsing/effects_provider/feature_parser.hpp
+++ b/src/core/parsing/effects_provider/feature_parser.hpp
@@ -17,7 +17,7 @@ namespace dnd {
 
 class FeatureParser : public Parser {
 public:
-    explicit FeatureParser(const std::filesystem::path& filepath) noexcept;
+    explicit FeatureParser(const std::filesystem::path& filepath);
     Errors parse_into(nlohmann::ordered_json&& json, Feature::Data& data) const;
     Errors parse_multiple_into(nlohmann::ordered_json&& json, std::vector<Feature::Data>& data) const;
 private:

--- a/src/core/parsing/file_parser.cpp
+++ b/src/core/parsing/file_parser.cpp
@@ -13,7 +13,7 @@
 
 namespace dnd {
 
-FileParser::FileParser(const std::filesystem::path& filepath, bool multiple_pieces_per_file) noexcept
+FileParser::FileParser(const std::filesystem::path& filepath, bool multiple_pieces_per_file)
     : Parser(filepath), multiple_pieces_per_file(multiple_pieces_per_file) {}
 
 Errors FileParser::open_json() {
@@ -39,7 +39,7 @@ Errors FileParser::open_json() {
     return errors;
 }
 
-bool FileParser::continue_after_errors() const noexcept { return multiple_pieces_per_file; }
+bool FileParser::continue_after_errors() const { return multiple_pieces_per_file; }
 
 void FileParser::set_context(const Content& content) { DND_UNUSED(content); }
 

--- a/src/core/parsing/file_parser.hpp
+++ b/src/core/parsing/file_parser.hpp
@@ -15,10 +15,10 @@ class Content;
 
 class FileParser : public Parser {
 public:
-    explicit FileParser(const std::filesystem::path& filepath, bool multiple_pieces_per_file) noexcept;
+    explicit FileParser(const std::filesystem::path& filepath, bool multiple_pieces_per_file);
     virtual Errors open_json() final;
     virtual Errors parse() = 0;
-    bool continue_after_errors() const noexcept;
+    bool continue_after_errors() const;
     virtual void set_context(const Content& content);
     virtual void save_result(Content& content) = 0;
 protected:

--- a/src/core/parsing/groups/choosable_group_parser.cpp
+++ b/src/core/parsing/groups/choosable_group_parser.cpp
@@ -15,7 +15,7 @@
 
 namespace dnd {
 
-ChoosableGroupParser::ChoosableGroupParser(const std::filesystem::path& filepath) noexcept
+ChoosableGroupParser::ChoosableGroupParser(const std::filesystem::path& filepath)
     : FileParser(filepath, true), choosable_parser(filepath) {}
 
 Errors ChoosableGroupParser::parse() {

--- a/src/core/parsing/groups/choosable_group_parser.hpp
+++ b/src/core/parsing/groups/choosable_group_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class ChoosableGroupParser : public FileParser {
 public:
-    explicit ChoosableGroupParser(const std::filesystem::path& filepath) noexcept;
+    explicit ChoosableGroupParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void save_result(Content& content) override;
 protected:

--- a/src/core/parsing/item/item_parser.cpp
+++ b/src/core/parsing/item/item_parser.cpp
@@ -44,7 +44,7 @@ Errors ItemParser::parse() {
         item_errors += parse_required_attribute_into(item_json, "requires_attunement", data.requires_attunement);
         item_errors += parse_optional_attribute_into(item_json, "cosmetic_description", data.cosmetic_description);
         if (item_errors.ok()) {
-            item_data.emplace_back(std::move(data));
+            item_data.push_back(std::move(data));
         }
         errors += std::move(item_errors);
     }

--- a/src/core/parsing/parser.cpp
+++ b/src/core/parsing/parser.cpp
@@ -6,8 +6,8 @@
 
 namespace dnd {
 
-const std::filesystem::path& Parser::get_filepath() const noexcept { return filepath; }
+const std::filesystem::path& Parser::get_filepath() const { return filepath; }
 
-Parser::Parser(const std::filesystem::path& filepath) noexcept : filepath(filepath) {}
+Parser::Parser(const std::filesystem::path& filepath) : filepath(filepath) {}
 
 } // namespace dnd

--- a/src/core/parsing/parser.hpp
+++ b/src/core/parsing/parser.hpp
@@ -19,11 +19,11 @@ namespace dnd {
 
 class Parser {
 public:
-    virtual ~Parser() noexcept = default;
+    virtual ~Parser() = default;
 
-    const std::filesystem::path& get_filepath() const noexcept;
+    const std::filesystem::path& get_filepath() const;
 protected:
-    explicit Parser(const std::filesystem::path& filepath) noexcept;
+    explicit Parser(const std::filesystem::path& filepath);
     template <typename T>
     Errors parse_optional_attribute_into(const nlohmann::json& json, const char* attribute_name, T& out) const;
     template <typename T>

--- a/src/core/parsing/species/species_parser.cpp
+++ b/src/core/parsing/species/species_parser.cpp
@@ -18,7 +18,7 @@
 
 namespace dnd {
 
-SpeciesParser::SpeciesParser(const std::filesystem::path& filepath) noexcept
+SpeciesParser::SpeciesParser(const std::filesystem::path& filepath)
     : FileParser(filepath, false), feature_parser(filepath), data() {}
 
 Errors SpeciesParser::parse() {

--- a/src/core/parsing/species/species_parser.hpp
+++ b/src/core/parsing/species/species_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class SpeciesParser : public FileParser {
 public:
-    explicit SpeciesParser(const std::filesystem::path& filepath) noexcept;
+    explicit SpeciesParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void save_result(Content& content) override;
 private:

--- a/src/core/parsing/spell/spell_parser.cpp
+++ b/src/core/parsing/spell/spell_parser.cpp
@@ -43,7 +43,7 @@ Errors SpellParser::parse() {
         spell_errors += parse_required_attribute_into(spell_json, "duration", data.duration);
         spell_errors += parse_required_attribute_into(spell_json, "classes", data.classes);
         if (spell_errors.ok()) {
-            spell_data.emplace_back(std::move(data));
+            spell_data.push_back(std::move(data));
         }
         errors += std::move(spell_errors);
     }

--- a/src/core/parsing/subclass/subclass_parser.cpp
+++ b/src/core/parsing/subclass/subclass_parser.cpp
@@ -18,7 +18,7 @@
 
 namespace dnd {
 
-SubclassParser::SubclassParser(const std::filesystem::path& filepath) noexcept
+SubclassParser::SubclassParser(const std::filesystem::path& filepath)
     : FileParser(filepath, false), class_feature_parser(filepath), data() {}
 
 Errors SubclassParser::parse() {

--- a/src/core/parsing/subclass/subclass_parser.hpp
+++ b/src/core/parsing/subclass/subclass_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class SubclassParser : public FileParser {
 public:
-    explicit SubclassParser(const std::filesystem::path& filepath) noexcept;
+    explicit SubclassParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void save_result(Content& content) override;
 private:

--- a/src/core/parsing/subspecies/subspecies_parser.cpp
+++ b/src/core/parsing/subspecies/subspecies_parser.cpp
@@ -17,7 +17,7 @@
 
 namespace dnd {
 
-SubspeciesParser::SubspeciesParser(const std::filesystem::path& filepath) noexcept
+SubspeciesParser::SubspeciesParser(const std::filesystem::path& filepath)
     : FileParser(filepath, false), feature_parser(filepath), data() {}
 
 Errors SubspeciesParser::parse() {

--- a/src/core/parsing/subspecies/subspecies_parser.hpp
+++ b/src/core/parsing/subspecies/subspecies_parser.hpp
@@ -16,7 +16,7 @@ namespace dnd {
 
 class SubspeciesParser : public FileParser {
 public:
-    explicit SubspeciesParser(const std::filesystem::path& filepath) noexcept;
+    explicit SubspeciesParser(const std::filesystem::path& filepath);
     virtual Errors parse() override;
     virtual void save_result(Content& content) override;
 private:

--- a/src/core/searching/advanced_search/advanced_content_search.cpp
+++ b/src/core/searching/advanced_search/advanced_content_search.cpp
@@ -12,12 +12,12 @@
 
 namespace dnd {
 
-AdvancedContentSearch::AdvancedContentSearch(const Content& content) noexcept
+AdvancedContentSearch::AdvancedContentSearch(const Content& content)
     : content(content), filter(ContentPieceFilter()), searching(false), search_future() {}
 
 ContentFilterVariant& AdvancedContentSearch::get_filter() { return filter; }
 
-const std::vector<const ContentPiece*>& AdvancedContentSearch::get_search_results() const noexcept {
+const std::vector<const ContentPiece*>& AdvancedContentSearch::get_search_results() const {
     return search_results;
 }
 

--- a/src/core/searching/advanced_search/advanced_content_search.cpp
+++ b/src/core/searching/advanced_search/advanced_content_search.cpp
@@ -17,9 +17,7 @@ AdvancedContentSearch::AdvancedContentSearch(const Content& content)
 
 ContentFilterVariant& AdvancedContentSearch::get_filter() { return filter; }
 
-const std::vector<const ContentPiece*>& AdvancedContentSearch::get_search_results() const {
-    return search_results;
-}
+const std::vector<const ContentPiece*>& AdvancedContentSearch::get_search_results() const { return search_results; }
 
 static std::vector<const ContentPiece*> search(const Content& content, ContentFilterVariant searching_filter) {
     std::vector<const ContentPiece*> search_results = std::visit(

--- a/src/core/searching/advanced_search/advanced_content_search.hpp
+++ b/src/core/searching/advanced_search/advanced_content_search.hpp
@@ -31,11 +31,11 @@ using ContentFilterVariant = std::variant<
  */
 class AdvancedContentSearch {
 public:
-    AdvancedContentSearch(const Content& content) noexcept;
+    AdvancedContentSearch(const Content& content);
     template <typename T>
     void set_filter(T&& new_filter);
     ContentFilterVariant& get_filter();
-    const std::vector<const ContentPiece*>& get_search_results() const noexcept;
+    const std::vector<const ContentPiece*>& get_search_results() const;
 
     void start_searching();
     /**

--- a/src/core/searching/content_filters/bool_filter.cpp
+++ b/src/core/searching/content_filters/bool_filter.cpp
@@ -4,19 +4,19 @@
 
 namespace dnd {
 
-BoolFilter::BoolFilter() noexcept : type(BoolFilterType::NONE) {}
+BoolFilter::BoolFilter() : type(BoolFilterType::NONE) {}
 
-bool BoolFilter::is_set() const noexcept { return type != BoolFilterType::NONE; }
+bool BoolFilter::is_set() const { return type != BoolFilterType::NONE; }
 
-BoolFilterType BoolFilter::get_type() const noexcept { return type; }
+BoolFilterType BoolFilter::get_type() const { return type; }
 
-void BoolFilter::set_type(BoolFilterType new_type) noexcept { type = new_type; }
+void BoolFilter::set_type(BoolFilterType new_type) { type = new_type; }
 
-void BoolFilter::set(BoolFilterType new_type) noexcept { set_type(new_type); }
+void BoolFilter::set(BoolFilterType new_type) { set_type(new_type); }
 
-void BoolFilter::clear() noexcept { type = BoolFilterType::NONE; }
+void BoolFilter::clear() { type = BoolFilterType::NONE; }
 
-bool BoolFilter::matches(bool boolean) const noexcept {
+bool BoolFilter::matches(bool boolean) const {
     switch (type) {
         case BoolFilterType::IS_TRUE:
             return boolean;

--- a/src/core/searching/content_filters/bool_filter.hpp
+++ b/src/core/searching/content_filters/bool_filter.hpp
@@ -13,13 +13,13 @@ enum class BoolFilterType {
 
 class BoolFilter {
 public:
-    BoolFilter() noexcept;
-    bool is_set() const noexcept;
-    BoolFilterType get_type() const noexcept;
-    void set_type(BoolFilterType new_type) noexcept;
-    void set(BoolFilterType new_type) noexcept;
-    void clear() noexcept;
-    bool matches(bool boolean) const noexcept;
+    BoolFilter();
+    bool is_set() const;
+    BoolFilterType get_type() const;
+    void set_type(BoolFilterType new_type);
+    void set(BoolFilterType new_type);
+    void clear();
+    bool matches(bool boolean) const;
 private:
     BoolFilterType type;
 };

--- a/src/core/searching/content_filters/character/character_filter.cpp
+++ b/src/core/searching/content_filters/character/character_filter.cpp
@@ -24,7 +24,7 @@ std::vector<const ContentPiece*> CharacterFilter::all_matches(const Content& con
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, character] : content.get_characters().get_all()) {
         if (matches(character)) {
-            matching_content_pieces.emplace_back(&character);
+            matching_content_pieces.push_back(&character);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/character/character_filter.cpp
+++ b/src/core/searching/content_filters/character/character_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool CharacterFilter::has_all_filters() const noexcept {
+bool CharacterFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && level_filter.is_set() && xp_filter.is_set();
 }
 
-bool CharacterFilter::matches(const Character& character) const noexcept {
+bool CharacterFilter::matches(const Character& character) const {
     return ContentPieceFilter::matches(character) && level_filter.matches(character.get_progression().get_level())
            && xp_filter.matches(character.get_progression().get_xp());
 }

--- a/src/core/searching/content_filters/character/character_filter.hpp
+++ b/src/core/searching/content_filters/character/character_filter.hpp
@@ -13,8 +13,8 @@ namespace dnd {
 
 class CharacterFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Character& character) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Character& character) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/class/class_filter.cpp
+++ b/src/core/searching/content_filters/class/class_filter.cpp
@@ -23,7 +23,7 @@ std::vector<const ContentPiece*> ClassFilter::all_matches(const Content& content
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, cls] : content.get_classes().get_all()) {
         if (matches(cls)) {
-            matching_content_pieces.emplace_back(&cls);
+            matching_content_pieces.push_back(&cls);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/class/class_filter.cpp
+++ b/src/core/searching/content_filters/class/class_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool ClassFilter::has_all_filters() const noexcept {
+bool ClassFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && has_spellcasting_filter.is_set();
 }
 
-bool ClassFilter::matches(const Class& cls) const noexcept {
+bool ClassFilter::matches(const Class& cls) const {
     return ContentPieceFilter::matches(cls) && has_spellcasting_filter.matches(cls.has_spellcasting());
 }
 

--- a/src/core/searching/content_filters/class/class_filter.hpp
+++ b/src/core/searching/content_filters/class/class_filter.hpp
@@ -11,8 +11,8 @@ namespace dnd {
 
 class ClassFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Class& cls) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Class& cls) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/content_filter.hpp
+++ b/src/core/searching/content_filters/content_filter.hpp
@@ -14,7 +14,7 @@ class Content;
 class ContentFilter {
 public:
     virtual ~ContentFilter() = default;
-    virtual bool has_all_filters() const noexcept = 0;
+    virtual bool has_all_filters() const = 0;
     virtual std::vector<const ContentPiece*> all_matches(const Content& content) const = 0;
     virtual void clear() = 0;
 };

--- a/src/core/searching/content_filters/content_piece_filter.cpp
+++ b/src/core/searching/content_filters/content_piece_filter.cpp
@@ -32,52 +32,52 @@ std::vector<const ContentPiece*> ContentPieceFilter::all_matches(const Content& 
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, character] : content.get_characters().get_all()) {
         if (matches(character)) {
-            matching_content_pieces.emplace_back(&character);
+            matching_content_pieces.push_back(&character);
         }
     }
     for (const auto& [_, cls] : content.get_classes().get_all()) {
         if (matches(cls)) {
-            matching_content_pieces.emplace_back(&cls);
+            matching_content_pieces.push_back(&cls);
         }
     }
     for (const auto& [_, subclass] : content.get_subclasses().get_all()) {
         if (matches(subclass)) {
-            matching_content_pieces.emplace_back(&subclass);
+            matching_content_pieces.push_back(&subclass);
         }
     }
     for (const auto& [_, species] : content.get_species().get_all()) {
         if (matches(species)) {
-            matching_content_pieces.emplace_back(&species);
+            matching_content_pieces.push_back(&species);
         }
     }
     for (const auto& [_, subspecies] : content.get_subspecies().get_all()) {
         if (matches(subspecies)) {
-            matching_content_pieces.emplace_back(&subspecies);
+            matching_content_pieces.push_back(&subspecies);
         }
     }
     for (const auto& [_, item] : content.get_items().get_all()) {
         if (matches(item)) {
-            matching_content_pieces.emplace_back(&item);
+            matching_content_pieces.push_back(&item);
         }
     }
     for (const auto& [_, spell] : content.get_spells().get_all()) {
         if (matches(spell)) {
-            matching_content_pieces.emplace_back(&spell);
+            matching_content_pieces.push_back(&spell);
         }
     }
     for (const auto& [_, feature] : content.get_features().get_all()) {
         if (matches(feature)) {
-            matching_content_pieces.emplace_back(&feature.get());
+            matching_content_pieces.push_back(&feature.get());
         }
     }
     for (const auto& [_, class_feature] : content.get_class_features().get_all()) {
         if (matches(class_feature)) {
-            matching_content_pieces.emplace_back(&class_feature.get());
+            matching_content_pieces.push_back(&class_feature.get());
         }
     }
     for (const auto& [_, choosable] : content.get_choosables().get_all()) {
         if (matches(choosable)) {
-            matching_content_pieces.emplace_back(&choosable);
+            matching_content_pieces.push_back(&choosable);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/content_piece_filter.cpp
+++ b/src/core/searching/content_filters/content_piece_filter.cpp
@@ -12,15 +12,15 @@
 
 namespace dnd {
 
-ContentPieceFilter::ContentPieceFilter() noexcept
+ContentPieceFilter::ContentPieceFilter()
     : name_filter(StringFilter()), description_filter(), is_sourcebook_filter() {}
 
-bool ContentPieceFilter::has_all_filters() const noexcept {
-    return std::visit([](const auto& filter) noexcept { return filter.is_set(); }, name_filter)
+bool ContentPieceFilter::has_all_filters() const {
+    return std::visit([](const auto& filter) { return filter.is_set(); }, name_filter)
            && description_filter.is_set() && is_sourcebook_filter.is_set();
 }
 
-bool ContentPieceFilter::matches(const ContentPiece& content_piece) const noexcept {
+bool ContentPieceFilter::matches(const ContentPiece& content_piece) const {
     return std::visit(
                [&content_piece](const auto& filter) { return filter.matches(content_piece.get_name()); }, name_filter
            )

--- a/src/core/searching/content_filters/content_piece_filter.cpp
+++ b/src/core/searching/content_filters/content_piece_filter.cpp
@@ -12,12 +12,11 @@
 
 namespace dnd {
 
-ContentPieceFilter::ContentPieceFilter()
-    : name_filter(StringFilter()), description_filter(), is_sourcebook_filter() {}
+ContentPieceFilter::ContentPieceFilter() : name_filter(StringFilter()), description_filter(), is_sourcebook_filter() {}
 
 bool ContentPieceFilter::has_all_filters() const {
-    return std::visit([](const auto& filter) { return filter.is_set(); }, name_filter)
-           && description_filter.is_set() && is_sourcebook_filter.is_set();
+    return std::visit([](const auto& filter) { return filter.is_set(); }, name_filter) && description_filter.is_set()
+           && is_sourcebook_filter.is_set();
 }
 
 bool ContentPieceFilter::matches(const ContentPiece& content_piece) const {

--- a/src/core/searching/content_filters/content_piece_filter.hpp
+++ b/src/core/searching/content_filters/content_piece_filter.hpp
@@ -20,9 +20,9 @@ class ContentPiece;
 
 class ContentPieceFilter : public ContentFilter {
 public:
-    ContentPieceFilter() noexcept;
-    bool has_all_filters() const noexcept override;
-    bool matches(const ContentPiece& content_piece) const noexcept;
+    ContentPieceFilter();
+    bool has_all_filters() const override;
+    bool matches(const ContentPiece& content_piece) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/effects_provider/choosable_filter.cpp
+++ b/src/core/searching/content_filters/effects_provider/choosable_filter.cpp
@@ -24,7 +24,7 @@ std::vector<const ContentPiece*> ChoosableFilter::all_matches(const Content& con
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, choosable] : content.get_choosables().get_all()) {
         if (matches(choosable)) {
-            matching_content_pieces.emplace_back(&choosable);
+            matching_content_pieces.push_back(&choosable);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/effects_provider/choosable_filter.cpp
+++ b/src/core/searching/content_filters/effects_provider/choosable_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool ChoosableFilter::has_all_filters() const noexcept {
+bool ChoosableFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && type_filter.is_set() && has_prerequisites_filter.is_set();
 }
 
-bool ChoosableFilter::matches(const Choosable& choosable) const noexcept {
+bool ChoosableFilter::matches(const Choosable& choosable) const {
     return ContentPieceFilter::matches(choosable) && type_filter.matches(choosable.get_type())
            && has_prerequisites_filter.matches(!choosable.get_prerequisites().empty());
 }

--- a/src/core/searching/content_filters/effects_provider/choosable_filter.hpp
+++ b/src/core/searching/content_filters/effects_provider/choosable_filter.hpp
@@ -12,8 +12,8 @@ namespace dnd {
 
 class ChoosableFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Choosable& choosable) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Choosable& choosable) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/effects_provider/feature_filter.cpp
+++ b/src/core/searching/content_filters/effects_provider/feature_filter.cpp
@@ -11,9 +11,9 @@
 
 namespace dnd {
 
-bool FeatureFilter::has_all_filters() const noexcept { return ContentPieceFilter::has_all_filters(); }
+bool FeatureFilter::has_all_filters() const { return ContentPieceFilter::has_all_filters(); }
 
-bool FeatureFilter::matches(const Feature& feature) const noexcept { return ContentPieceFilter::matches(feature); }
+bool FeatureFilter::matches(const Feature& feature) const { return ContentPieceFilter::matches(feature); }
 
 std::vector<const ContentPiece*> FeatureFilter::all_matches(const Content& content) const {
     std::vector<const ContentPiece*> matching_content_pieces;

--- a/src/core/searching/content_filters/effects_provider/feature_filter.cpp
+++ b/src/core/searching/content_filters/effects_provider/feature_filter.cpp
@@ -19,7 +19,7 @@ std::vector<const ContentPiece*> FeatureFilter::all_matches(const Content& conte
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, feature] : content.get_features().get_all()) {
         if (matches(feature)) {
-            matching_content_pieces.emplace_back(&feature.get());
+            matching_content_pieces.push_back(&feature.get());
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/effects_provider/feature_filter.hpp
+++ b/src/core/searching/content_filters/effects_provider/feature_filter.hpp
@@ -14,8 +14,8 @@ namespace dnd {
 
 class FeatureFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Feature& feature) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Feature& feature) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 };

--- a/src/core/searching/content_filters/item/item_filter.cpp
+++ b/src/core/searching/content_filters/item/item_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool ItemFilter::has_all_filters() const noexcept {
+bool ItemFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && cosmetic_description_filter.is_set() && attunement_filter.is_set();
 }
 
-bool ItemFilter::matches(const Item& item) const noexcept {
+bool ItemFilter::matches(const Item& item) const {
     return ContentPieceFilter::matches(item) && cosmetic_description_filter.matches(item.get_cosmetic_description())
            && attunement_filter.matches(item.requires_attunement());
 }

--- a/src/core/searching/content_filters/item/item_filter.cpp
+++ b/src/core/searching/content_filters/item/item_filter.cpp
@@ -24,7 +24,7 @@ std::vector<const ContentPiece*> ItemFilter::all_matches(const Content& content)
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, item] : content.get_items().get_all()) {
         if (matches(item)) {
-            matching_content_pieces.emplace_back(&item);
+            matching_content_pieces.push_back(&item);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/item/item_filter.hpp
+++ b/src/core/searching/content_filters/item/item_filter.hpp
@@ -14,8 +14,8 @@ namespace dnd {
 
 class ItemFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Item& item) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Item& item) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/number_filter.hpp
+++ b/src/core/searching/content_filters/number_filter.hpp
@@ -21,15 +21,15 @@ template <typename T>
 requires std::is_arithmetic_v<T>
 class NumberFilter {
 public:
-    NumberFilter() noexcept;
-    bool is_set() const noexcept;
-    NumberFilterType get_type() const noexcept;
-    T get_value() const noexcept;
-    void set_type(NumberFilterType new_type) noexcept;
-    void set_value(T new_value) noexcept;
-    void set(NumberFilterType type, T new_value) noexcept;
-    void clear() noexcept;
-    bool matches(T number) const noexcept;
+    NumberFilter();
+    bool is_set() const;
+    NumberFilterType get_type() const;
+    T get_value() const;
+    void set_type(NumberFilterType new_type);
+    void set_value(T new_value);
+    void set(NumberFilterType type, T new_value);
+    void clear();
+    bool matches(T number) const;
 private:
     NumberFilterType type;
     T value;
@@ -40,55 +40,55 @@ private:
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-NumberFilter<T>::NumberFilter() noexcept : type(NumberFilterType::NONE), value(0) {}
+NumberFilter<T>::NumberFilter() : type(NumberFilterType::NONE), value(0) {}
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-bool NumberFilter<T>::is_set() const noexcept {
+bool NumberFilter<T>::is_set() const {
     return type != NumberFilterType::NONE;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-NumberFilterType NumberFilter<T>::get_type() const noexcept {
+NumberFilterType NumberFilter<T>::get_type() const {
     return type;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-T NumberFilter<T>::get_value() const noexcept {
+T NumberFilter<T>::get_value() const {
     return value;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-void NumberFilter<T>::set_type(NumberFilterType new_type) noexcept {
+void NumberFilter<T>::set_type(NumberFilterType new_type) {
     type = new_type;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-void NumberFilter<T>::set_value(T new_value) noexcept {
+void NumberFilter<T>::set_value(T new_value) {
     value = new_value;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-void NumberFilter<T>::set(NumberFilterType new_type, T new_value) noexcept {
+void NumberFilter<T>::set(NumberFilterType new_type, T new_value) {
     set_type(new_type);
     set_value(new_value);
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-void NumberFilter<T>::clear() noexcept {
+void NumberFilter<T>::clear() {
     type = NumberFilterType::NONE;
     value = 0;
 }
 
 template <typename T>
 requires std::is_arithmetic_v<T>
-bool NumberFilter<T>::matches(T number) const noexcept {
+bool NumberFilter<T>::matches(T number) const {
     switch (type) {
         case NumberFilterType::EQUAL:
             return number == value;

--- a/src/core/searching/content_filters/selection_filter.hpp
+++ b/src/core/searching/content_filters/selection_filter.hpp
@@ -18,17 +18,17 @@ enum class SelectionFilterType {
 template <typename T>
 class SelectionFilter {
 public:
-    SelectionFilter() noexcept;
-    bool is_set() const noexcept;
-    SelectionFilterType get_type() const noexcept;
-    const std::vector<T>& get_values() const noexcept;
-    void set_type(SelectionFilterType new_type) noexcept;
-    void set_values(const std::vector<T>& values) noexcept;
-    void set_values(std::vector<T>&& values) noexcept;
-    void set(SelectionFilterType new_type, const std::vector<T>& values) noexcept;
-    void set(SelectionFilterType new_type, std::vector<T>&& new_values) noexcept;
-    void clear() noexcept;
-    bool matches(const T& selection) const noexcept;
+    SelectionFilter();
+    bool is_set() const;
+    SelectionFilterType get_type() const;
+    const std::vector<T>& get_values() const;
+    void set_type(SelectionFilterType new_type);
+    void set_values(const std::vector<T>& values);
+    void set_values(std::vector<T>&& values);
+    void set(SelectionFilterType new_type, const std::vector<T>& values);
+    void set(SelectionFilterType new_type, std::vector<T>&& new_values);
+    void clear();
+    bool matches(const T& selection) const;
 private:
     SelectionFilterType type;
     std::vector<T> values;
@@ -38,58 +38,58 @@ private:
 // === IMPLEMENTATION ===
 
 template <typename T>
-SelectionFilter<T>::SelectionFilter() noexcept : type(SelectionFilterType::NONE), values() {}
+SelectionFilter<T>::SelectionFilter() : type(SelectionFilterType::NONE), values() {}
 
 template <typename T>
-bool SelectionFilter<T>::is_set() const noexcept {
+bool SelectionFilter<T>::is_set() const {
     return type != SelectionFilterType::NONE;
 }
 
 template <typename T>
-SelectionFilterType SelectionFilter<T>::get_type() const noexcept {
+SelectionFilterType SelectionFilter<T>::get_type() const {
     return type;
 }
 
 template <typename T>
-const std::vector<T>& SelectionFilter<T>::get_values() const noexcept {
+const std::vector<T>& SelectionFilter<T>::get_values() const {
     return values;
 }
 
 template <typename T>
-void SelectionFilter<T>::set_type(SelectionFilterType new_type) noexcept {
+void SelectionFilter<T>::set_type(SelectionFilterType new_type) {
     type = new_type;
 }
 
 template <typename T>
-void SelectionFilter<T>::set_values(const std::vector<T>& new_values) noexcept {
+void SelectionFilter<T>::set_values(const std::vector<T>& new_values) {
     values = new_values;
 }
 
 template <typename T>
-void SelectionFilter<T>::set_values(std::vector<T>&& new_values) noexcept {
+void SelectionFilter<T>::set_values(std::vector<T>&& new_values) {
     values = std::move(new_values);
 }
 
 template <typename T>
-void SelectionFilter<T>::set(SelectionFilterType new_type, const std::vector<T>& new_values) noexcept {
+void SelectionFilter<T>::set(SelectionFilterType new_type, const std::vector<T>& new_values) {
     set_type(new_type);
     set_values(new_values);
 }
 
 template <typename T>
-void SelectionFilter<T>::set(SelectionFilterType new_type, std::vector<T>&& new_values) noexcept {
+void SelectionFilter<T>::set(SelectionFilterType new_type, std::vector<T>&& new_values) {
     set_type(new_type);
     set_values(std::move(new_values));
 }
 
 template <typename T>
-void SelectionFilter<T>::clear() noexcept {
+void SelectionFilter<T>::clear() {
     type = SelectionFilterType::NONE;
     values.clear();
 }
 
 template <typename T>
-bool SelectionFilter<T>::matches(const T& selection) const noexcept {
+bool SelectionFilter<T>::matches(const T& selection) const {
     switch (type) {
         case SelectionFilterType::IS_IN:
             return std::find(values.begin(), values.end(), selection) != values.end();

--- a/src/core/searching/content_filters/species/species_filter.cpp
+++ b/src/core/searching/content_filters/species/species_filter.cpp
@@ -23,7 +23,7 @@ std::vector<const ContentPiece*> SpeciesFilter::all_matches(const Content& conte
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, species] : content.get_species().get_all()) {
         if (matches(species)) {
-            matching_content_pieces.emplace_back(&species);
+            matching_content_pieces.push_back(&species);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/species/species_filter.cpp
+++ b/src/core/searching/content_filters/species/species_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool SpeciesFilter::has_all_filters() const noexcept {
+bool SpeciesFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && has_subspecies_filter.is_set();
 }
 
-bool SpeciesFilter::matches(const Species& species) const noexcept {
+bool SpeciesFilter::matches(const Species& species) const {
     return ContentPieceFilter::matches(species) && has_subspecies_filter.matches(species.has_subspecies());
 }
 

--- a/src/core/searching/content_filters/species/species_filter.hpp
+++ b/src/core/searching/content_filters/species/species_filter.hpp
@@ -12,8 +12,8 @@ namespace dnd {
 
 class SpeciesFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Species& species) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Species& species) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/spell/spell_filter.cpp
+++ b/src/core/searching/content_filters/spell/spell_filter.cpp
@@ -40,7 +40,7 @@ std::vector<const ContentPiece*> SpellFilter::all_matches(const Content& content
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, spell] : content.get_spells().get_all()) {
         if (matches(spell)) {
-            matching_content_pieces.emplace_back(&spell);
+            matching_content_pieces.push_back(&spell);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/spell/spell_filter.cpp
+++ b/src/core/searching/content_filters/spell/spell_filter.cpp
@@ -12,7 +12,7 @@
 
 namespace dnd {
 
-bool SpellFilter::has_all_filters() const noexcept {
+bool SpellFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && verbal_component_filter.is_set()
            && somatic_component_filter.is_set() && material_component_filter.is_set() && level_filter.is_set()
            && magic_school_filter.is_set() && ritual_filter.is_set() && casting_time_filter.is_set()
@@ -20,7 +20,7 @@ bool SpellFilter::has_all_filters() const noexcept {
 }
 
 
-bool SpellFilter::matches(const Spell& spell) const noexcept {
+bool SpellFilter::matches(const Spell& spell) const {
     const SpellComponents& components = spell.get_components();
     const MagicSchool& magic_school = spell.get_type().get_magic_school();
     return ContentPieceFilter::matches(spell) && verbal_component_filter.matches(components.has_verbal())

--- a/src/core/searching/content_filters/spell/spell_filter.hpp
+++ b/src/core/searching/content_filters/spell/spell_filter.hpp
@@ -19,8 +19,8 @@ class Spell;
 
 class SpellFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Spell& spell) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Spell& spell) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/string_filter.cpp
+++ b/src/core/searching/content_filters/string_filter.cpp
@@ -6,38 +6,38 @@
 
 namespace dnd {
 
-StringFilter::StringFilter() noexcept : type(StringFilterType::NONE), value() {}
+StringFilter::StringFilter() : type(StringFilterType::NONE), value() {}
 
-bool StringFilter::is_set() const noexcept { return type != StringFilterType::NONE; }
+bool StringFilter::is_set() const { return type != StringFilterType::NONE; }
 
-StringFilterType StringFilter::get_type() const noexcept { return type; }
+StringFilterType StringFilter::get_type() const { return type; }
 
-std::string& StringFilter::get_value_mutable() noexcept { return value; }
+std::string& StringFilter::get_value_mutable() { return value; }
 
-const std::string& StringFilter::get_value() const noexcept { return value; }
+const std::string& StringFilter::get_value() const { return value; }
 
-void StringFilter::set_type(StringFilterType new_type) noexcept { type = new_type; }
+void StringFilter::set_type(StringFilterType new_type) { type = new_type; }
 
-void StringFilter::set_value(const std::string& new_value) noexcept { value = new_value; }
+void StringFilter::set_value(const std::string& new_value) { value = new_value; }
 
-void StringFilter::set_value(std::string&& new_value) noexcept { value = new_value; }
+void StringFilter::set_value(std::string&& new_value) { value = new_value; }
 
-void StringFilter::set(StringFilterType new_type, const std::string& new_value) noexcept {
+void StringFilter::set(StringFilterType new_type, const std::string& new_value) {
     set_type(new_type);
     set_value(new_value);
 }
 
-void StringFilter::set(StringFilterType new_type, std::string&& new_value) noexcept {
+void StringFilter::set(StringFilterType new_type, std::string&& new_value) {
     set_type(new_type);
     set_value(std::move(new_value));
 }
 
-void StringFilter::clear() noexcept {
+void StringFilter::clear() {
     set_type(StringFilterType::NONE);
     set_value("");
 }
 
-bool StringFilter::matches(const std::string& str) const noexcept {
+bool StringFilter::matches(const std::string& str) const {
     switch (type) {
         case StringFilterType::EQUAL:
             return str == value;

--- a/src/core/searching/content_filters/string_filter.hpp
+++ b/src/core/searching/content_filters/string_filter.hpp
@@ -21,18 +21,18 @@ enum class StringFilterType {
 
 class StringFilter {
 public:
-    StringFilter() noexcept;
-    bool is_set() const noexcept;
-    StringFilterType get_type() const noexcept;
-    std::string& get_value_mutable() noexcept;
-    const std::string& get_value() const noexcept;
-    void set_type(StringFilterType new_type) noexcept;
-    void set_value(const std::string& new_value) noexcept;
-    void set_value(std::string&& new_value) noexcept;
-    void set(StringFilterType new_type, const std::string& new_value) noexcept;
-    void set(StringFilterType new_type, std::string&& new_value) noexcept;
-    void clear() noexcept;
-    bool matches(const std::string& str) const noexcept;
+    StringFilter();
+    bool is_set() const;
+    StringFilterType get_type() const;
+    std::string& get_value_mutable();
+    const std::string& get_value() const;
+    void set_type(StringFilterType new_type);
+    void set_value(const std::string& new_value);
+    void set_value(std::string&& new_value);
+    void set(StringFilterType new_type, const std::string& new_value);
+    void set(StringFilterType new_type, std::string&& new_value);
+    void clear();
+    bool matches(const std::string& str) const;
 private:
     StringFilterType type;
     std::string value;

--- a/src/core/searching/content_filters/subclass/subclass_filter.cpp
+++ b/src/core/searching/content_filters/subclass/subclass_filter.cpp
@@ -11,11 +11,11 @@
 
 namespace dnd {
 
-bool SubclassFilter::has_all_filters() const noexcept {
+bool SubclassFilter::has_all_filters() const {
     return ContentPieceFilter::has_all_filters() && has_spellcasting_filter.is_set();
 }
 
-bool SubclassFilter::matches(const Subclass& subclass) const noexcept {
+bool SubclassFilter::matches(const Subclass& subclass) const {
     return ContentPieceFilter::matches(subclass) && has_spellcasting_filter.matches(subclass.has_spellcasting());
 }
 

--- a/src/core/searching/content_filters/subclass/subclass_filter.cpp
+++ b/src/core/searching/content_filters/subclass/subclass_filter.cpp
@@ -23,7 +23,7 @@ std::vector<const ContentPiece*> SubclassFilter::all_matches(const Content& cont
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, subclass] : content.get_subclasses().get_all()) {
         if (matches(subclass)) {
-            matching_content_pieces.emplace_back(&subclass);
+            matching_content_pieces.push_back(&subclass);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/subclass/subclass_filter.hpp
+++ b/src/core/searching/content_filters/subclass/subclass_filter.hpp
@@ -13,8 +13,8 @@ namespace dnd {
 
 class SubclassFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Subclass& subclass) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Subclass& subclass) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 

--- a/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
+++ b/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
@@ -21,7 +21,7 @@ std::vector<const ContentPiece*> SubspeciesFilter::all_matches(const Content& co
     std::vector<const ContentPiece*> matching_content_pieces;
     for (const auto& [_, subspecies] : content.get_subspecies().get_all()) {
         if (matches(subspecies)) {
-            matching_content_pieces.emplace_back(&subspecies);
+            matching_content_pieces.push_back(&subspecies);
         }
     }
     return matching_content_pieces;

--- a/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
+++ b/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
@@ -11,9 +11,9 @@
 
 namespace dnd {
 
-bool SubspeciesFilter::has_all_filters() const noexcept { return ContentPieceFilter::has_all_filters(); }
+bool SubspeciesFilter::has_all_filters() const { return ContentPieceFilter::has_all_filters(); }
 
-bool SubspeciesFilter::matches(const Subspecies& subspecies) const noexcept {
+bool SubspeciesFilter::matches(const Subspecies& subspecies) const {
     return ContentPieceFilter::matches(subspecies);
 }
 

--- a/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
+++ b/src/core/searching/content_filters/subspecies/subspecies_filter.cpp
@@ -13,9 +13,7 @@ namespace dnd {
 
 bool SubspeciesFilter::has_all_filters() const { return ContentPieceFilter::has_all_filters(); }
 
-bool SubspeciesFilter::matches(const Subspecies& subspecies) const {
-    return ContentPieceFilter::matches(subspecies);
-}
+bool SubspeciesFilter::matches(const Subspecies& subspecies) const { return ContentPieceFilter::matches(subspecies); }
 
 std::vector<const ContentPiece*> SubspeciesFilter::all_matches(const Content& content) const {
     std::vector<const ContentPiece*> matching_content_pieces;

--- a/src/core/searching/content_filters/subspecies/subspecies_filter.hpp
+++ b/src/core/searching/content_filters/subspecies/subspecies_filter.hpp
@@ -12,8 +12,8 @@ namespace dnd {
 
 class SubspeciesFilter : public ContentPieceFilter {
 public:
-    bool has_all_filters() const noexcept override;
-    bool matches(const Subspecies& subspecies) const noexcept;
+    bool has_all_filters() const override;
+    bool matches(const Subspecies& subspecies) const;
     std::vector<const ContentPiece*> all_matches(const Content& content) const override;
     void clear() override;
 };

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -44,9 +44,7 @@ const std::vector<std::string>& Session::get_unknown_error_messages() const { re
 
 const std::vector<std::string>& Session::get_parsing_error_messages() const { return parsing_error_messages; }
 
-const std::vector<std::string>& Session::get_validation_error_messages() const {
-    return validation_error_messages;
-}
+const std::vector<std::string>& Session::get_validation_error_messages() const { return validation_error_messages; }
 
 const std::string& Session::get_campaign_name() const { return campaign_name; }
 

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -73,7 +73,7 @@ std::vector<std::string> Session::get_possible_campaign_names() const {
         if (!entry.is_directory() || entry.path().filename() == "general") {
             continue;
         }
-        campaign_names.emplace_back(entry.path().filename().string());
+        campaign_names.push_back(entry.path().filename().string());
     }
     return campaign_names;
 }
@@ -331,7 +331,7 @@ void Session::parse_content_and_initialize() {
             case 0: {
                 const ParsingError& parsing_error = std::get<ParsingError>(error);
                 SourceInfo source_info(parsing_error.get_filepath());
-                parsing_error_messages.emplace_back(fmt::format(
+                parsing_error_messages.push_back(fmt::format(
                     "{} ({} - {} - {})", parsing_error.get_error_message(), source_info.get_source_group_name(),
                     source_info.get_source_type_name(), source_info.get_source_name()
                 ));
@@ -339,12 +339,12 @@ void Session::parse_content_and_initialize() {
             }
             case 1: {
                 const ValidationError& validation_error = std::get<ValidationError>(error);
-                validation_error_messages.emplace_back(validation_error.get_error_message());
+                validation_error_messages.push_back(validation_error.get_error_message());
                 break;
             }
             case 2: {
                 const RuntimeError& runtime_error = std::get<RuntimeError>(error);
-                unknown_error_messages.emplace_back(runtime_error.get_error_message());
+                unknown_error_messages.push_back(runtime_error.get_error_message());
                 break;
             }
         }

--- a/src/core/session.cpp
+++ b/src/core/session.cpp
@@ -34,35 +34,35 @@ Session::Session(const char* last_session_filename)
 
 Session::~Session() { save_session_values(); }
 
-SessionStatus Session::get_status() const noexcept { return status; }
+SessionStatus Session::get_status() const { return status; }
 
-Content& Session::get_content() noexcept { return content; }
+Content& Session::get_content() { return content; }
 
-const Errors& Session::get_errors() const noexcept { return errors; }
+const Errors& Session::get_errors() const { return errors; }
 
-const std::vector<std::string>& Session::get_unknown_error_messages() const noexcept { return unknown_error_messages; }
+const std::vector<std::string>& Session::get_unknown_error_messages() const { return unknown_error_messages; }
 
-const std::vector<std::string>& Session::get_parsing_error_messages() const noexcept { return parsing_error_messages; }
+const std::vector<std::string>& Session::get_parsing_error_messages() const { return parsing_error_messages; }
 
-const std::vector<std::string>& Session::get_validation_error_messages() const noexcept {
+const std::vector<std::string>& Session::get_validation_error_messages() const {
     return validation_error_messages;
 }
 
-const std::string& Session::get_campaign_name() const noexcept { return campaign_name; }
+const std::string& Session::get_campaign_name() const { return campaign_name; }
 
-const std::filesystem::path& Session::get_content_directory() const noexcept { return content_directory; }
+const std::filesystem::path& Session::get_content_directory() const { return content_directory; }
 
-std::deque<const ContentPiece*>& Session::get_open_content_pieces() noexcept { return open_content_pieces; }
+std::deque<const ContentPiece*>& Session::get_open_content_pieces() { return open_content_pieces; }
 
-const ContentPiece* Session::get_selected_content_piece() noexcept {
+const ContentPiece* Session::get_selected_content_piece() {
     const ContentPiece* rv = selected_content_piece;
     selected_content_piece = nullptr;
     return rv;
 }
 
-size_t Session::get_fuzzy_search_result_count() const noexcept { return fuzzy_search_result_count; }
+size_t Session::get_fuzzy_search_result_count() const { return fuzzy_search_result_count; }
 
-bool Session::too_many_fuzzy_search_results() const noexcept { return fuzzy_search_result_count > max_search_results; }
+bool Session::too_many_fuzzy_search_results() const { return fuzzy_search_result_count > max_search_results; }
 
 std::vector<std::string> Session::get_possible_campaign_names() const {
     if (content_directory.empty()) {

--- a/src/core/session.hpp
+++ b/src/core/session.hpp
@@ -33,20 +33,20 @@ class Session {
 public:
     Session(const char* last_session_filename = "last_session.ini");
     ~Session();
-    SessionStatus get_status() const noexcept;
-    Content& get_content() noexcept;
+    SessionStatus get_status() const;
+    Content& get_content();
 
-    const Errors& get_errors() const noexcept;
-    const std::vector<std::string>& get_unknown_error_messages() const noexcept;
-    const std::vector<std::string>& get_parsing_error_messages() const noexcept;
-    const std::vector<std::string>& get_validation_error_messages() const noexcept;
+    const Errors& get_errors() const;
+    const std::vector<std::string>& get_unknown_error_messages() const;
+    const std::vector<std::string>& get_parsing_error_messages() const;
+    const std::vector<std::string>& get_validation_error_messages() const;
     void clear_unknown_error_messages();
 
-    const std::string& get_campaign_name() const noexcept;
-    const std::filesystem::path& get_content_directory() const noexcept;
+    const std::string& get_campaign_name() const;
+    const std::filesystem::path& get_content_directory() const;
 
-    std::deque<const ContentPiece*>& get_open_content_pieces() noexcept;
-    const ContentPiece* get_selected_content_piece() noexcept;
+    std::deque<const ContentPiece*>& get_open_content_pieces();
+    const ContentPiece* get_selected_content_piece();
 
     std::vector<std::string> get_possible_campaign_names() const;
     void retrieve_last_session_values();
@@ -55,8 +55,8 @@ public:
     Errors set_campaign_name(const std::string& campaign_name);
     Errors set_content_directory(const std::filesystem::path& content_directory);
 
-    size_t get_fuzzy_search_result_count() const noexcept;
-    bool too_many_fuzzy_search_results() const noexcept;
+    size_t get_fuzzy_search_result_count() const;
+    bool too_many_fuzzy_search_results() const;
     std::vector<std::string> get_fuzzy_search_result_strings() const;
     void set_fuzzy_search(const std::string& search_query, const std::array<bool, 9>& search_options);
     void open_fuzzy_search_result(size_t index);

--- a/src/core/utils/data_result.hpp
+++ b/src/core/utils/data_result.hpp
@@ -20,16 +20,16 @@ namespace dnd {
 template <typename OutputT, typename DataT>
 class DataResult {
 public:
-    static DataResult valid(OutputT&& output) noexcept;
-    static DataResult invalid(DataT&& data, Errors&& errors) noexcept;
+    static DataResult valid(OutputT&& output);
+    static DataResult invalid(DataT&& data, Errors&& errors);
 
-    bool is_valid() const noexcept;
+    bool is_valid() const;
     const OutputT& value_ref() const;
     OutputT&& value();
     const std::pair<DataT, Errors>& data_and_errors_ref() const;
     std::pair<DataT, Errors>&& data_and_errors();
 private:
-    DataResult(tl::expected<OutputT, std::pair<DataT, Errors>>&& inner) noexcept;
+    DataResult(tl::expected<OutputT, std::pair<DataT, Errors>>&& inner);
 
     tl::expected<OutputT, std::pair<DataT, Errors>> inner;
 };
@@ -40,10 +40,10 @@ template <typename T>
 using CreateResult = DataResult<T, typename T::Data>;
 
 template <typename T>
-CreateResult<T> ValidCreate(T&& output) noexcept;
+CreateResult<T> ValidCreate(T&& output);
 
 template <typename T>
-CreateResult<T> InvalidCreate(typename T::Data&& data, Errors&& errors) noexcept;
+CreateResult<T> InvalidCreate(typename T::Data&& data, Errors&& errors);
 
 // holds a result of an attempt to construct an object from data where the constructed object is polymorphic
 // it either holds the constructed object or the invalid data and the errors that caused it to be invalid
@@ -51,26 +51,26 @@ template <typename T>
 using FactoryResult = DataResult<std::unique_ptr<T>, typename T::Data>;
 
 template <typename T>
-FactoryResult<T> ValidFactory(std::unique_ptr<T>&& output) noexcept;
+FactoryResult<T> ValidFactory(std::unique_ptr<T>&& output);
 
 template <typename T>
-FactoryResult<T> InvalidFactory(typename T::Data&& data, Errors&& errors) noexcept;
+FactoryResult<T> InvalidFactory(typename T::Data&& data, Errors&& errors);
 
 
 // === IMPLEMENTATION ===
 
 template <typename OutputT, typename DataT>
-DataResult<OutputT, DataT> DataResult<OutputT, DataT>::valid(OutputT&& output) noexcept {
+DataResult<OutputT, DataT> DataResult<OutputT, DataT>::valid(OutputT&& output) {
     return DataResult(tl::expected<OutputT, std::pair<DataT, Errors>>(std::move(output)));
 }
 
 template <typename OutputT, typename DataT>
-DataResult<OutputT, DataT> DataResult<OutputT, DataT>::invalid(DataT&& data, Errors&& errors) noexcept {
+DataResult<OutputT, DataT> DataResult<OutputT, DataT>::invalid(DataT&& data, Errors&& errors) {
     return DataResult(tl::unexpected(std::make_pair(std::move(data), std::move(errors))));
 }
 
 template <typename OutputT, typename DataT>
-bool DataResult<OutputT, DataT>::is_valid() const noexcept {
+bool DataResult<OutputT, DataT>::is_valid() const {
     return inner.has_value();
 }
 
@@ -95,27 +95,27 @@ std::pair<DataT, Errors>&& DataResult<OutputT, DataT>::data_and_errors() {
 }
 
 template <typename OutputT, typename DataT>
-DataResult<OutputT, DataT>::DataResult(tl::expected<OutputT, std::pair<DataT, Errors>>&& inner) noexcept
+DataResult<OutputT, DataT>::DataResult(tl::expected<OutputT, std::pair<DataT, Errors>>&& inner)
     : inner(std::move(inner)) {}
 
 
 template <typename T>
-CreateResult<T> ValidCreate(T&& output) noexcept {
+CreateResult<T> ValidCreate(T&& output) {
     return CreateResult<T>::valid(std::move(output));
 }
 
 template <typename T>
-CreateResult<T> InvalidCreate(typename T::Data&& data, Errors&& errors) noexcept {
+CreateResult<T> InvalidCreate(typename T::Data&& data, Errors&& errors) {
     return CreateResult<T>::invalid(std::move(data), std::move(errors));
 }
 
 template <typename T>
-FactoryResult<T> ValidFactory(std::unique_ptr<T>&& output) noexcept {
+FactoryResult<T> ValidFactory(std::unique_ptr<T>&& output) {
     return FactoryResult<T>::valid(std::move(output));
 }
 
 template <typename T>
-FactoryResult<T> InvalidFactory(typename T::Data&& data, Errors&& errors) noexcept {
+FactoryResult<T> InvalidFactory(typename T::Data&& data, Errors&& errors) {
     return FactoryResult<T>::invalid(std::move(data), std::move(errors));
 }
 

--- a/src/core/visitors/content/list_content_visitor.cpp
+++ b/src/core/visitors/content/list_content_visitor.cpp
@@ -25,7 +25,7 @@ void ListContentVisitor::reserve(size_t size) { string_list.reserve(size); }
 std::vector<std::string> ListContentVisitor::get_list() { return std::move(string_list); }
 
 void ListContentVisitor::operator()(const Character& character) {
-    string_list.emplace_back(fmt::format(
+    string_list.push_back(fmt::format(
         "{} [CHARACTER] : Level {} {} {}", character.get_name(), character.get_progression().get_level(),
         character.get_feature_providers().get_class().get_name(),
         character.get_feature_providers().get_species().get_name()
@@ -33,42 +33,42 @@ void ListContentVisitor::operator()(const Character& character) {
 }
 
 void ListContentVisitor::operator()(const Class& cls) {
-    string_list.emplace_back(fmt::format("{} [CLASS]", cls.get_name()));
+    string_list.push_back(fmt::format("{} [CLASS]", cls.get_name()));
 }
 
 void ListContentVisitor::operator()(const Subclass& subclass) {
     const Class& cls = subclass.get_class();
-    string_list.emplace_back(fmt::format("{} [{} SUBCLASS]", subclass.get_name(), cls.get_name()));
+    string_list.push_back(fmt::format("{} [{} SUBCLASS]", subclass.get_name(), cls.get_name()));
 }
 void ListContentVisitor::operator()(const Species& species) {
-    string_list.emplace_back(fmt::format("{} [SPECIES]", species.get_name()));
+    string_list.push_back(fmt::format("{} [SPECIES]", species.get_name()));
 }
 
 void ListContentVisitor::operator()(const Subspecies& subspecies) {
     const Species& species = subspecies.get_species();
-    string_list.emplace_back(fmt::format("{} [{} SUBSPECIES]", subspecies.get_name(), species.get_name()));
+    string_list.push_back(fmt::format("{} [{} SUBSPECIES]", subspecies.get_name(), species.get_name()));
 }
 
 void ListContentVisitor::operator()(const Item& item) {
     if (item.requires_attunement()) {
-        string_list.emplace_back(fmt::format("{} [ITEM] requires attunement", item.get_name()));
+        string_list.push_back(fmt::format("{} [ITEM] requires attunement", item.get_name()));
     } else {
-        string_list.emplace_back(fmt::format("{} [ITEM] no attunement", item.get_name()));
+        string_list.push_back(fmt::format("{} [ITEM] no attunement", item.get_name()));
     }
 }
 
 void ListContentVisitor::operator()(const Spell& spell) {
-    string_list.emplace_back(fmt::format("{} [SPELL] : {}", spell.get_name(), spell.get_type().short_str()));
+    string_list.push_back(fmt::format("{} [SPELL] : {}", spell.get_name(), spell.get_type().short_str()));
 }
 
 void ListContentVisitor::operator()(const Feature& feature) {
-    string_list.emplace_back(
+    string_list.push_back(
         fmt::format("{} [FEATURE] : {}", feature.get_name(), feature.get_source_info().get_beautified_source_path())
     );
 }
 
 void ListContentVisitor::operator()(const Choosable& choosable) {
-    string_list.emplace_back(fmt::format(
+    string_list.push_back(fmt::format(
         "{} [CHOOSABLE] : {}", choosable.get_name(), choosable.get_source_info().get_beautified_source_path()
     ));
 }

--- a/src/gui/visitors/filters/filter_setting_visitor.cpp
+++ b/src/gui/visitors/filters/filter_setting_visitor.cpp
@@ -279,7 +279,7 @@ static void selection_menu_item(const char* name, SelectionFilter<T>& filter, Se
 
 static void content_piece_filter_menu_items(ContentPieceFilter& content_piece_filter) {
     bool name_filter_set = std::visit(
-        [](const auto& filter) noexcept { return filter.is_set(); }, content_piece_filter.name_filter
+        [](const auto& filter) { return filter.is_set(); }, content_piece_filter.name_filter
     );
     if (!name_filter_set && ImGui::MenuItem("Name")) {
         content_piece_filter.name_filter.emplace<StringFilter>().set_type(StringFilterType::EQUAL);

--- a/src/runtime_measurement/measurer.cpp
+++ b/src/runtime_measurement/measurer.cpp
@@ -48,7 +48,7 @@ void Measurer::endSession() {
             long idx = it - thread_ids.begin();
             measurement.at("tid") = idx;
         } else {
-            thread_ids.emplace_back(measurement.at("tid"));
+            thread_ids.push_back(measurement.at("tid"));
             measurement.at("tid") = next_id++;
         }
     }

--- a/src/runtime_measurement/measurer.hpp
+++ b/src/runtime_measurement/measurer.hpp
@@ -45,7 +45,7 @@ public:
     /**
      * @brief Constructs a Measurer
      */
-    Measurer() noexcept;
+    Measurer();
     /**
      * @brief Starts a measuring session with a certain name
      * @param name a name for the measuring session
@@ -100,7 +100,7 @@ private:
 
 inline std::mutex Measurer::write_profile_mutex;
 
-inline Measurer::Measurer() noexcept : session(nullptr) {}
+inline Measurer::Measurer() : session(nullptr) {}
 
 inline Measurer& Measurer::get() {
     static Measurer instance;

--- a/tests/helper/argv.hpp
+++ b/tests/helper/argv.hpp
@@ -44,7 +44,7 @@ inline Argv::Argv(std::initializer_list<const char*> args)
         auto ptr = std::unique_ptr<char[]>(new char[len]);
 
         strcpy(ptr.get(), *iter);
-        m_args.emplace_back(std::move(ptr));
+        m_args.push_back(std::move(ptr));
         m_argv.get()[i] = m_args.back().get();
 
         iter++;

--- a/tests/testcore/validation/validation_data_mock.hpp
+++ b/tests/testcore/validation/validation_data_mock.hpp
@@ -14,7 +14,7 @@ void set_valid_mock_values(dnd::ValidationData& data, const char* data_name = nu
 
 class ValidationDataMock : public dnd::ValidationData {
 public:
-    std::strong_ordering operator<=>(const ValidationDataMock&) const noexcept = default;
+    std::strong_ordering operator<=>(const ValidationDataMock&) const = default;
 };
 
 } // namespace dnd::test


### PR DESCRIPTION
I had a totally wrong understanding of the `noexcept` keyword.
This PR removes all the wrong usages of `noexcept` in the code base and only adds it where it may actually be required and/or helpul (move operations, some constructors).