### PR TITLE
Character stats

### DIFF
--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -26,6 +26,7 @@ static std::string get_error_message(const Error& error) {
         case 1:
             return fmt::format("Validation Error: {}", std::get<ValidationError>(error).get_error_message());
     }
+    assert(false);
     return "";
 }
 

--- a/src/cli/cli_app.cpp
+++ b/src/cli/cli_app.cpp
@@ -25,9 +25,8 @@ static std::string get_error_message(const Error& error) {
             return fmt::format("Parsing Error: {}", std::get<ParsingError>(error).get_error_message());
         case 1:
             return fmt::format("Validation Error: {}", std::get<ValidationError>(error).get_error_message());
-        default:
-            return "";
     }
+    return "";
 }
 
 void CliApp::initialize(

--- a/src/core/basic_mechanics/abilities.cpp
+++ b/src/core/basic_mechanics/abilities.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <stdexcept>
 #include <string>
 #include <string_view>

--- a/src/core/basic_mechanics/abilities.cpp
+++ b/src/core/basic_mechanics/abilities.cpp
@@ -33,11 +33,9 @@ std::string ability_to_string(Ability ability) {
             return "WIS";
         case Ability::CHARISMA:
             return "CHA";
-        default:
-            throw std::invalid_argument(
-                "The ability \"" + std::to_string(static_cast<int>(ability)) + "\" does not exist."
-            );
     }
+    assert(false);
+    return "";
 }
 
 bool is_ability(std::string_view attribute_name) {

--- a/src/core/basic_mechanics/abilities.cpp
+++ b/src/core/basic_mechanics/abilities.cpp
@@ -5,22 +5,22 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <stdexcept>
+#include <optional>
 #include <string>
 #include <string_view>
 
 namespace dnd {
 
-Ability string_to_ability(const std::string& ability_str) {
+std::optional<Ability> ability_from_string(const std::string& ability_str) {
     for (size_t i = 0; i < 6; ++i) {
         if (ability_cstrings_inorder[i] == ability_str) {
             return abilities_inorder[i];
         }
     }
-    throw std::invalid_argument("The ability \"" + ability_str + "\" does not exist.");
+    return std::nullopt;
 }
 
-std::string ability_to_string(Ability ability) {
+std::string ability_name(Ability ability) {
     switch (ability) {
         case Ability::STRENGTH:
             return "STR";

--- a/src/core/basic_mechanics/abilities.hpp
+++ b/src/core/basic_mechanics/abilities.hpp
@@ -4,6 +4,7 @@
 #include <dnd_config.hpp>
 
 #include <array>
+#include <optional>
 #include <string>
 #include <string_view>
 

--- a/src/core/basic_mechanics/abilities.hpp
+++ b/src/core/basic_mechanics/abilities.hpp
@@ -9,9 +9,6 @@
 
 namespace dnd {
 
-/**
- * @brief An enum for the basic 6 abilities
- */
 enum class Ability {
     STRENGTH,
     DEXTERITY,
@@ -21,12 +18,11 @@ enum class Ability {
     CHARISMA,
 };
 
-// the abilities in order
 inline constexpr std::array<Ability, 6> abilities_inorder = {
     Ability::STRENGTH,     Ability::DEXTERITY, Ability::CONSTITUTION,
     Ability::INTELLIGENCE, Ability::WISDOM,    Ability::CHARISMA,
 };
-// the 3-letter c-style strings for the abilities in order
+
 inline constexpr std::array<const char*, 6> ability_cstrings_inorder = {"STR", "DEX", "CON", "INT", "WIS", "CHA"};
 
 /**

--- a/src/core/basic_mechanics/abilities.hpp
+++ b/src/core/basic_mechanics/abilities.hpp
@@ -25,33 +25,10 @@ inline constexpr std::array<Ability, 6> abilities_inorder = {
 
 inline constexpr std::array<const char*, 6> ability_cstrings_inorder = {"STR", "DEX", "CON", "INT", "WIS", "CHA"};
 
-/**
- * @brief Given the 3-letter string representation of an ability, returns the ability value.
- * @param ability_str the 3-letter string representing an ability (e.g. "DEX")
- * @return the ability the 3-letter string represents
- * @throws std::invalid_argument if the string doesn't represent any of the 6 abilities
- */
-Ability string_to_ability(const std::string& ability_str);
+std::optional<Ability> ability_from_string(const std::string& ability_str);
+std::string ability_name(Ability ability);
 
-/**
- * @brief Given a certain ability, return the 3-letter string representation
- * @param ability the ability
- * @return the 3-letter string representation of the ability
- */
-std::string ability_to_string(Ability ability);
-
-/**
- * @brief Checks whether the given 3-letter string represents an ability
- * @param attribute_name the 3-letter string representation of an ability as string_view
- * @return "true" if string represents an ability, "false" otherwise
- */
 bool is_ability(std::string_view attribute_name);
-
-/**
- * @brief Checks whether the given 3-letter string represents an ability
- * @param attribute_name the 3-letter string representation of an ability
- * @return "true" if string represents an ability, "false" otherwise
- */
 bool is_ability(const std::string& attribute_name);
 
 } // namespace dnd

--- a/src/core/basic_mechanics/dice.cpp
+++ b/src/core/basic_mechanics/dice.cpp
@@ -2,6 +2,7 @@
 
 #include "dice.hpp"
 
+#include <cassert>
 #include <map>
 #include <string>
 

--- a/src/core/basic_mechanics/dice.cpp
+++ b/src/core/basic_mechanics/dice.cpp
@@ -30,13 +30,12 @@ static tl::expected<DiceType, Errors> int_to_dice_type(int number) {
             return DiceType::D20;
         case 100:
             return DiceType::D100;
-        default:
-            Errors errors(RuntimeError(
-                RuntimeError::Code::INVALID_ARGUMENT,
-                fmt::format("Invalid dice number '{}' - must be 4, 6, 8, 10, 12, 20, or 100", number)
-            ));
-            return tl::unexpected(errors);
     };
+    Errors errors(RuntimeError(
+        RuntimeError::Code::INVALID_ARGUMENT,
+        fmt::format("Invalid dice number '{}' - must be 4, 6, 8, 10, 12, 20, or 100", number)
+    ));
+    return tl::unexpected(errors);
 }
 
 static tl::expected<DiceType, Errors> string_to_dice_type(const std::string& lowercase_str) {
@@ -63,7 +62,7 @@ static tl::expected<DiceType, Errors> string_to_dice_type(const std::string& low
     }
 }
 
-static tl::expected<const char*, Errors> dice_type_to_string(DiceType dice_type) {
+static const char* dice_type_to_string(DiceType dice_type) {
     switch (dice_type) {
         case DiceType::D4:
             return "d4";
@@ -79,12 +78,9 @@ static tl::expected<const char*, Errors> dice_type_to_string(DiceType dice_type)
             return "d20";
         case DiceType::D100:
             return "d100";
-        default:
-            Errors errors(RuntimeError(
-                RuntimeError::Code::UNREACHABLE, "Invalid dice type in switch statement (dice_type_to_string)"
-            ));
-            return tl::unexpected(errors);
     };
+    assert(false);
+    return "";
 }
 
 

--- a/src/core/models/character/CMakeLists.txt
+++ b/src/core/models/character/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(${DND_CORE}
     character.cpp
     feature_providers.cpp
     progression.cpp
+    stats.cpp
 )
 
 add_subdirectory(decision)

--- a/src/core/models/character/ability_scores.cpp
+++ b/src/core/models/character/ability_scores.cpp
@@ -2,6 +2,8 @@
 
 #include "ability_scores.hpp"
 
+#include <cassert>
+
 #include <core/basic_mechanics/abilities.hpp>
 #include <core/errors/errors.hpp>
 #include <core/errors/validation_error.hpp>
@@ -37,9 +39,9 @@ int AbilityScores::get(Ability ability) const {
             return wisdom;
         case Ability::CHARISMA:
             return charisma;
-        default:
-            return 0;
     }
+    assert(false);
+    return 0;
 }
 
 int AbilityScores::get_strength() const { return strength; }
@@ -68,9 +70,9 @@ int AbilityScores::get_modifier(Ability ability) const {
             return get_wisdom_modifier();
         case Ability::CHARISMA:
             return get_charisma_modifier();
-        default:
-            return 0;
     }
+    assert(false);
+    return 0;
 }
 
 int AbilityScores::get_strength_modifier() const { return calculate_modifier(strength); }

--- a/src/core/models/character/stats.cpp
+++ b/src/core/models/character/stats.cpp
@@ -1,19 +1,48 @@
-#include <algorithm>
 #include <dnd_config.hpp>
 
-#include "core/basic_mechanics/skills.hpp"
 #include "stats.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <string>
 #include <unordered_map>
 
-dnd::Stats dnd::Stats::create_default() noexcept {
+#include <fmt/format.h>
+
+#include <core/basic_mechanics/abilities.hpp>
+#include <core/basic_mechanics/skills.hpp>
+
+namespace dnd {
+
+static int calculate_modifier(int score) noexcept { return score / 2 - 5; }
+
+Stats Stats::create_default() noexcept {
     Stats stats;
     return stats;
 }
 
-dnd::Stats::Stats() noexcept {
+Stats Stats::create_from_base_scores_and_stat_changes(
+    const AbilityScores& base_ability_scores, std::vector<CRef<StatChange>> stat_changes
+) noexcept {
+    Stats stats;
+    stats.mutable_values["STR"] = base_ability_scores.get_strength();
+    stats.mutable_values["DEX"] = base_ability_scores.get_dexterity();
+    stats.mutable_values["CON"] = base_ability_scores.get_constitution();
+    stats.mutable_values["INT"] = base_ability_scores.get_intelligence();
+    stats.mutable_values["WIS"] = base_ability_scores.get_wisdom();
+    stats.mutable_values["CHA"] = base_ability_scores.get_charisma();
+
+    // TODO: Apply all stat changes for the ability scores
+
+    stats.calculate_ability_modifiers();
+    stats.calculate_skill_modifiers();
+
+    // TODO: Apply all other stat changes
+
+    return stats;
+}
+
+Stats::Stats() noexcept {
     mutable_values["STR"] = 10;
     mutable_values["DEX"] = 10;
     mutable_values["CON"] = 10;
@@ -22,7 +51,7 @@ dnd::Stats::Stats() noexcept {
     mutable_values["CHA"] = 10;
 }
 
-bool dnd::Stats::is_complete() const noexcept {
+bool Stats::is_complete() const noexcept {
     assert(mutable_values.contains("STR"));
     assert(mutable_values.contains("DEX"));
     assert(mutable_values.contains("CON"));
@@ -32,9 +61,34 @@ bool dnd::Stats::is_complete() const noexcept {
     bool has_ability_modifiers = mutable_values.contains("STR_MOD") && mutable_values.contains("DEX_MOD")
                                  && mutable_values.contains("CON_MOD") && mutable_values.contains("INT_MOD")
                                  && mutable_values.contains("WIS_MOD") && mutable_values.contains("CHA_MOD");
-    auto all_skills = get_all_skills();
+    std::vector<std::string> all_skills = get_all_skills();
     bool has_skill_modifiers = std::all_of(all_skills.begin(), all_skills.end(), [this](const std::string& skill) {
         return mutable_values.contains(skill);
     });
     return has_ability_modifiers && has_skill_modifiers;
 }
+
+void Stats::calculate_ability_modifiers() noexcept {
+    assert(mutable_values.contains("STR"));
+    implied_values["STR_MOD"] = (mutable_values["STR"] - 10) / 2;
+    assert(mutable_values.contains("DEX"));
+    implied_values["DEX_MOD"] = (mutable_values["DEX"] - 10) / 2;
+    assert(mutable_values.contains("CON"));
+    implied_values["CON_MOD"] = (mutable_values["CON"] - 10) / 2;
+    assert(mutable_values.contains("INT"));
+    implied_values["INT_MOD"] = (mutable_values["INT"] - 10) / 2;
+    assert(mutable_values.contains("WIS"));
+    implied_values["WIS_MOD"] = (mutable_values["WIS"] - 10) / 2;
+    assert(mutable_values.contains("CHA"));
+    implied_values["CHA_MOD"] = (mutable_values["CHA"] - 10) / 2;
+}
+
+void Stats::calculate_skill_modifiers() noexcept {
+    for (const auto& [skill, ability] : get_abilities_for_all_skills()) {
+        const std::string ability_modifier = ability + "_MOD";
+        assert(implied_values.contains(ability_modifier));
+        mutable_values[skill] = implied_values[ability_modifier];
+    }
+}
+
+} // namespace dnd

--- a/src/core/models/character/stats.cpp
+++ b/src/core/models/character/stats.cpp
@@ -1,0 +1,40 @@
+#include <algorithm>
+#include <dnd_config.hpp>
+
+#include "core/basic_mechanics/skills.hpp"
+#include "stats.hpp"
+
+#include <cassert>
+#include <string>
+#include <unordered_map>
+
+dnd::Stats dnd::Stats::create_default() noexcept {
+    Stats stats;
+    return stats;
+}
+
+dnd::Stats::Stats() noexcept {
+    mutable_values["STR"] = 10;
+    mutable_values["DEX"] = 10;
+    mutable_values["CON"] = 10;
+    mutable_values["INT"] = 10;
+    mutable_values["WIS"] = 10;
+    mutable_values["CHA"] = 10;
+}
+
+bool dnd::Stats::is_complete() const noexcept {
+    assert(mutable_values.contains("STR"));
+    assert(mutable_values.contains("DEX"));
+    assert(mutable_values.contains("CON"));
+    assert(mutable_values.contains("INT"));
+    assert(mutable_values.contains("WIS"));
+    assert(mutable_values.contains("CHA"));
+    bool has_ability_modifiers = mutable_values.contains("STR_MOD") && mutable_values.contains("DEX_MOD")
+                                 && mutable_values.contains("CON_MOD") && mutable_values.contains("INT_MOD")
+                                 && mutable_values.contains("WIS_MOD") && mutable_values.contains("CHA_MOD");
+    auto all_skills = get_all_skills();
+    bool has_skill_modifiers = std::all_of(all_skills.begin(), all_skills.end(), [this](const std::string& skill) {
+        return mutable_values.contains(skill);
+    });
+    return has_ability_modifiers && has_skill_modifiers;
+}

--- a/src/core/models/character/stats.hpp
+++ b/src/core/models/character/stats.hpp
@@ -1,0 +1,25 @@
+#ifndef STATS_HPP_
+#define STATS_HPP_
+
+#include <dnd_config.hpp>
+
+#include <string>
+#include <unordered_map>
+
+namespace dnd {
+
+class Stats {
+public:
+    static Stats create_default() noexcept;
+    Stats() noexcept;
+
+    bool is_complete() const noexcept;
+    void derive_implied_values() noexcept;
+private:
+    std::unordered_map<std::string, int> constant_values;
+    std::unordered_map<std::string, int> mutable_values;
+};
+
+} // namespace dnd
+
+#endif // STATS_HPP_

--- a/src/core/models/character/stats.hpp
+++ b/src/core/models/character/stats.hpp
@@ -5,19 +5,31 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
+
+#include <core/models/character/ability_scores.hpp>
+#include <core/models/effects/stat_change/stat_change.hpp>
+#include <core/utils/types.hpp>
 
 namespace dnd {
 
 class Stats {
 public:
     static Stats create_default() noexcept;
+    static Stats create_from_base_scores_and_stat_changes(
+        const AbilityScores& base_ability_scores, std::vector<CRef<StatChange>> stat_changes
+    ) noexcept;
     Stats() noexcept;
 
     bool is_complete() const noexcept;
-    void derive_implied_values() noexcept;
 private:
-    std::unordered_map<std::string, int> constant_values;
+    void derive_values_from_ability_scores() noexcept;
+    void calculate_ability_modifiers() noexcept;
+    void calculate_skill_modifiers() noexcept;
+
+    std::unordered_map<std::string, const int> constant_values;
     std::unordered_map<std::string, int> mutable_values;
+    std::unordered_map<std::string, int> implied_values;
 };
 
 } // namespace dnd

--- a/src/core/models/character/stats.hpp
+++ b/src/core/models/character/stats.hpp
@@ -3,6 +3,7 @@
 
 #include <dnd_config.hpp>
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -15,17 +16,24 @@ namespace dnd {
 
 class Stats {
 public:
-    static Stats create_default() noexcept;
+    static Stats create_default();
     static Stats create_from_base_scores_and_stat_changes(
         const AbilityScores& base_ability_scores, std::vector<CRef<StatChange>> stat_changes
-    ) noexcept;
-    Stats() noexcept;
+    );
 
-    bool is_complete() const noexcept;
+    Stats();
+
+    bool is_complete() const;
+    std::optional<int> get(const std::string& name) const;
+    int get_or_default(const std::string& name) const;
+    int get_or_else(const std::string& name, int default_value) const;
+    std::optional<Ref<int>> get_mut(const std::string& name);
+    int& get_mut_or_default(const std::string& name);
+    int& get_mut_or_else(const std::string& name, int default_value);
 private:
-    void derive_values_from_ability_scores() noexcept;
-    void calculate_ability_modifiers() noexcept;
-    void calculate_skill_modifiers() noexcept;
+    void derive_values_from_ability_scores();
+    void calculate_ability_modifiers();
+    void calculate_skill_modifiers();
 
     std::unordered_map<std::string, const int> constant_values;
     std::unordered_map<std::string, int> mutable_values;

--- a/src/core/models/effects/choice/choice.cpp
+++ b/src/core/models/effects/choice/choice.cpp
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include <fmt/format.h>
 #include <tl/expected.hpp>
 
 #include <core/basic_mechanics/abilities.hpp>
@@ -123,7 +124,15 @@ CreateResult<Choice> Choice::create_for(Data&& data, const Content& content) {
         group_names.push_back(data.attribute_name);
     }
 
-    ChoiceType type = choice_type_for_attribute_name(data.attribute_name);
+    std::optional<ChoiceType> type_optional = choice_type_for_attribute_name(data.attribute_name);
+    if (!type_optional.has_value()) {
+        errors.add_validation_error(
+            ValidationError::Code::INVALID_ATTRIBUTE_VALUE,
+            fmt::format("Choice has invalid attribute name '{}'", data.attribute_name)
+        );
+        return InvalidCreate<Choice>(std::move(data), std::move(errors));
+    }
+    ChoiceType type = type_optional.value();
     std::vector<std::unique_ptr<ContentFilter>> filters;
     switch (type) { // TODO: complete this switch
         case ChoiceType::ABILITY:

--- a/src/core/models/effects/choice/choice.cpp
+++ b/src/core/models/effects/choice/choice.cpp
@@ -141,10 +141,7 @@ CreateResult<Choice> Choice::create_for(Data&& data, const Content& content) {
             break;
         case ChoiceType::CHOOSABLE:
             break;
-        default:
-            break;
     }
-
     return ValidCreate(Choice(
         type, std::move(filters), std::move(data.attribute_name), data.amount, std::move(group_names),
         std::move(data.explicit_choices)
@@ -157,17 +154,17 @@ int Choice::get_amount() const { return amount; }
 
 std::set<std::string> Choice::possible_values(const Content& content) const {
     std::set<std::string> possible_values;
-    switch (type) {
+    switch (type) { // TODO: implement correct filters
         case ChoiceType::ABILITY:
             for (const char* ability : ability_cstrings_inorder) {
                 possible_values.emplace(ability);
             }
-            break;
+            return possible_values;
         case ChoiceType::SKILL:
             for (const std::string& skill : get_all_skills()) {
                 possible_values.emplace(skill);
             };
-            break;
+            return possible_values;
         case ChoiceType::STRING:
             for (const std::string& group_name : group_names) {
                 for (const std::string& group_member : content.get_groups().get_group(group_name)) {
@@ -179,26 +176,25 @@ std::set<std::string> Choice::possible_values(const Content& content) const {
             for (const std::string& explicit_choice : explicit_choices) {
                 possible_values.emplace(explicit_choice);
             };
-            break;
+            return possible_values;
         case ChoiceType::ITEM:
             for (const auto& [_, item] : content.get_items().get_all()) {
                 possible_values.emplace(item.get_name());
             };
-            break;
+            return possible_values;
         case ChoiceType::SPELL:
             // TODO: use the spell filters instead of this
             for (const auto& [_, spell] : content.get_spells().get_all()) {
                 possible_values.emplace(spell.get_name());
             };
-            break;
+            return possible_values;
         case ChoiceType::CHOOSABLE:
             for (const auto& [_, choosable] : content.get_choosables().get_all()) {
                 possible_values.emplace(choosable.get_name());
             };
-            break;
-        default:
-            break;
+            return possible_values;
     }
+    assert(false);
     return possible_values;
 }
 

--- a/src/core/models/effects/choice/choice_rules.cpp
+++ b/src/core/models/effects/choice/choice_rules.cpp
@@ -3,7 +3,7 @@
 #include "choice_rules.hpp"
 
 #include <array>
-#include <stdexcept>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
@@ -42,13 +42,13 @@ bool is_valid_choice_attribute_name(const std::string& attribute_name) {
     return false;
 }
 
-ChoiceType choice_type_for_attribute_name(const std::string& attribute_name) {
+std::optional<ChoiceType> choice_type_for_attribute_name(const std::string& attribute_name) {
     for (const auto& [valid_attribute_name, choice_type] : valid_attribute_names) {
         if (valid_attribute_name == attribute_name) {
             return choice_type;
         }
     }
-    throw std::invalid_argument("Invalid choice attribute name: " + attribute_name);
+    return std::nullopt;
 }
 
 static constexpr std::array<std::pair<std::string_view, std::string_view>, 9> valid_group_names = {
@@ -72,13 +72,13 @@ bool attribute_name_implies_group(const std::string& attribute_name) {
     return false;
 }
 
-std::string group_name_for_attribute_name(const std::string& attribute_name) {
+std::optional<std::string> group_name_for_attribute_name(const std::string& attribute_name) {
     for (const auto& [proficiency_name, group_name] : valid_group_names) {
         if (proficiency_name == attribute_name) {
             return std::string(group_name);
         }
     }
-    throw std::invalid_argument("Attribute name '" + attribute_name + "' does not imply a group of strings");
+    return std::nullopt;
 }
 
 } // namespace dnd

--- a/src/core/models/effects/choice/choice_rules.hpp
+++ b/src/core/models/effects/choice/choice_rules.hpp
@@ -3,6 +3,7 @@
 
 #include <dnd_config.hpp>
 
+#include <optional>
 #include <string>
 
 namespace dnd {
@@ -17,35 +18,11 @@ enum class ChoiceType {
     CHOOSABLE,
 };
 
-/**
- * @brief Returns whether the given attribute name is a valid choice attribute name
- * @param attribute_name the attribute name to check
- * @return "true" if the given attribute name is a valid choice attribute name, "false" otherwise
- */
 bool is_valid_choice_attribute_name(const std::string& attribute_name);
+std::optional<ChoiceType> choice_type_for_attribute_name(const std::string& attribute_name);
 
-/**
- * @brief Determines the choice type for the given attribute name
- * @param attribute_name the attribute name to determine the choice type for
- * @return the choice type for the given attribute name
- * @throws std::invalid_argument if the given attribute name is not a valid choice attribute name
- */
-ChoiceType choice_type_for_attribute_name(const std::string& attribute_name);
-
-/**
- * @brief Returns whether the given attribute name implies a group of strings
- * @param attribute_name the attribute name to check
- * @return "true" if the given attribute name implies a group of strings, "false" otherwise
- */
 bool attribute_name_implies_group(const std::string& attribute_name);
-
-/**
- * @brief Determines the group name for the given attribute name if the attribute name implies a group of strings
- * @param attribute_name the attribute name to determine the group name for
- * @return the group name for the given attribute name if the attribute name implies a group of strings
- * @throws std::invalid_argument if the given attribute name is not a valid choice attribute name
- */
-std::string group_name_for_attribute_name(const std::string& attribute_name);
+std::optional<std::string> group_name_for_attribute_name(const std::string& attribute_name);
 
 } // namespace dnd
 

--- a/src/core/models/effects/condition/condition_factory.cpp
+++ b/src/core/models/effects/condition/condition_factory.cpp
@@ -4,9 +4,12 @@
 
 #include <algorithm>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
+
+#include <fmt/format.h>
 
 #include <core/errors/errors.hpp>
 #include <core/exceptions/validation_exceptions.hpp>
@@ -18,6 +21,23 @@
 #include <core/validation/effects/condition/condition_validation.hpp>
 
 namespace dnd {
+
+static std::optional<ComparisonOperator> comparison_operator_from_str(std::string_view str) {
+    if (str == "==") {
+        return ComparisonOperator::EQUAL;
+    } else if (str == "!=") {
+        return ComparisonOperator::NOT_EQUAL;
+    } else if (str == "<") {
+        return ComparisonOperator::LESS_THAN;
+    } else if (str == "<=") {
+        return ComparisonOperator::LESS_THAN_OR_EQUAL;
+    } else if (str == ">") {
+        return ComparisonOperator::GREATER_THAN;
+    } else if (str == ">=") {
+        return ComparisonOperator::GREATER_THAN_OR_EQUAL;
+    }
+    return std::nullopt;
+}
 
 FactoryResult<Condition> create_condition(Condition::Data&& data) {
     Errors errors = validate_condition(data);
@@ -32,20 +52,32 @@ FactoryResult<Condition> create_condition(Condition::Data&& data) {
     const std::string_view operator_name = str_view(last_it, it);
     const std::string_view right_side_identifier = str_view(++it, data.condition_str.cend());
 
+    std::optional<ComparisonOperator> comparison_operator_optional = comparison_operator_from_str(operator_name);
+    if (!comparison_operator_optional.has_value()) {
+        Errors sub_errors(ValidationError(
+            ValidationError::Code::INVALID_ATTRIBUTE_VALUE,
+            fmt::format("Invalid comparison operator '{}'", operator_name)
+        ));
+        return InvalidFactory<Condition>(std::move(data), std::move(sub_errors));
+    }
+    ComparisonOperator comparison_operator = comparison_operator_optional.value();
+
     std::unique_ptr<Condition> condition;
     if (right_side_identifier[0] >= 'A' && right_side_identifier[0] <= 'Z') {
-        condition = std::make_unique<IdentifierCondition>(left_side_identifier, operator_name, right_side_identifier);
+        condition = std::make_unique<IdentifierCondition>(
+            left_side_identifier, comparison_operator, right_side_identifier
+        );
     } else if (right_side_identifier == "true" || right_side_identifier == "false") {
         condition = std::make_unique<LiteralCondition>(
-            left_side_identifier, operator_name, right_side_identifier == "true"
+            left_side_identifier, comparison_operator, right_side_identifier == "true"
         );
     } else if (right_side_identifier.find('.') != std::string::npos) {
         condition = std::make_unique<LiteralCondition>(
-            left_side_identifier, operator_name, std::stof(right_side_identifier.data())
+            left_side_identifier, comparison_operator, std::stof(std::string(right_side_identifier))
         );
     } else {
         condition = std::make_unique<LiteralCondition>(
-            left_side_identifier, operator_name, std::stoi(right_side_identifier.data())
+            left_side_identifier, comparison_operator, std::stoi(std::string(right_side_identifier))
         );
     }
     return ValidFactory(std::move(condition));

--- a/src/core/models/effects/condition/identifier_condition.cpp
+++ b/src/core/models/effects/condition/identifier_condition.cpp
@@ -2,49 +2,41 @@
 
 #include "identifier_condition.hpp"
 
-#include <functional>
-#include <stdexcept>
+#include <optional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <fmt/format.h>
+#include <tl/expected.hpp>
+
+#include <core/errors/runtime_error.hpp>
+#include <core/models/character/stats.hpp>
 #include <core/models/effects/condition/condition.hpp>
 
 namespace dnd {
 
 IdentifierCondition::IdentifierCondition(
-    const std::string& left_side_identifier, const std::string& operator_name, const std::string& right_side_identifier
+    const std::string& left_side_identifier, ComparisonOperator comparison_operator,
+    const std::string& right_side_identifier
 )
-    : Condition(left_side_identifier, operator_name), right_side_identifier(right_side_identifier) {}
+    : Condition(left_side_identifier, comparison_operator), right_side_identifier(right_side_identifier) {}
 
 IdentifierCondition::IdentifierCondition(
-    std::string_view left_side_identifier, std::string_view operator_name, std::string_view right_side_identifier
+    std::string_view left_side_identifier, ComparisonOperator comparison_operator,
+    std::string_view right_side_identifier
 )
-    : Condition(left_side_identifier, operator_name), right_side_identifier(right_side_identifier) {}
+    : Condition(left_side_identifier, comparison_operator), right_side_identifier(right_side_identifier) {}
 
-bool IdentifierCondition::evaluate(
-    const std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-) const {
-    if (comparison_operator == nullptr) {
-        return false;
+tl::expected<bool, RuntimeError> IdentifierCondition::evaluate(const Stats& stats) const {
+    std::optional<int> right_side_optional = stats.get(right_side_identifier);
+    if (!right_side_optional.has_value()) {
+        return tl::unexpected(RuntimeError(
+            RuntimeError::Code::INVALID_ARGUMENT,
+            fmt::format("Condition right side identifier '{}' not found in stats", right_side_identifier)
+        ));
     }
-    int left_side_value;
-    if (attributes.contains(left_side_identifier)) {
-        left_side_value = attributes.at(left_side_identifier);
-    } else if (constants.contains(left_side_identifier)) {
-        left_side_value = constants.at(left_side_identifier);
-    } else {
-        throw std::out_of_range("Identifier \"" + left_side_identifier + "\" not found.");
-    }
-    int right_side_value;
-    if (attributes.contains(right_side_identifier)) {
-        right_side_value = attributes.at(right_side_identifier);
-    } else if (constants.contains(right_side_identifier)) {
-        right_side_value = constants.at(right_side_identifier);
-    } else {
-        throw std::out_of_range("Identifier \"" + right_side_identifier + "\" not found.");
-    }
-    return comparison_operator(left_side_value, right_side_value);
+    int right_side_value = right_side_optional.value();
+    return evaluate_with_right_side(stats, right_side_value);
 }
 
 } // namespace dnd

--- a/src/core/models/effects/condition/identifier_condition.hpp
+++ b/src/core/models/effects/condition/identifier_condition.hpp
@@ -5,52 +5,27 @@
 
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <tl/expected.hpp>
+
+#include <core/errors/runtime_error.hpp>
+#include <core/models/character/stats.hpp>
 #include <core/models/effects/condition/condition.hpp>
 
 namespace dnd {
 
-/**
- * @brief A class that represents a condition that compares two character values (attributes or constants) using
- * their identifiers
- */
 class IdentifierCondition : public Condition {
 public:
-    /**
-     * @brief Constructs a condition with the given identifiers and operator
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side_identifier the identifier on the right side of the condition
-     */
     IdentifierCondition(
-        const std::string& left_side_identifier, const std::string& operator_name,
+        const std::string& left_side_identifier, ComparisonOperator comparison_operator,
         const std::string& right_side_identifier
     );
-    /**
-     * @brief Constructs a condition with the given identifiers and operator
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side_identifier the identifier on the right side of the condition
-     */
     IdentifierCondition(
-        std::string_view left_side_identifier, std::string_view operator_name, std::string_view right_side_identifier
+        std::string_view left_side_identifier, ComparisonOperator comparison_operator,
+        std::string_view right_side_identifier
     );
-    /**
-     * @brief Evaluates the condition for given attributes and constants
-     * @param attributes a map of attributes
-     * @param constants a map of constants
-     * @return "true" if the condition is fulfilled, "false" otherwise (or if the operator does not exist)
-     * @throws std::out_of_range if the identifiers used in the condition don't exist among the given attributes and
-     * constants
-     */
-    virtual bool evaluate(
-        const std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const override final;
+
+    tl::expected<bool, RuntimeError> evaluate(const Stats& stats) const override final;
 private:
     std::string right_side_identifier;
 };

--- a/src/core/models/effects/condition/literal_condition.cpp
+++ b/src/core/models/effects/condition/literal_condition.cpp
@@ -2,56 +2,49 @@
 
 #include "literal_condition.hpp"
 
-#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <tl/expected.hpp>
+
+#include <core/errors/runtime_error.hpp>
+#include <core/models/character/stats.hpp>
 #include <core/models/effects/condition/condition.hpp>
 
 namespace dnd {
 
 LiteralCondition::LiteralCondition(
-    const std::string& left_side_identifier, const std::string& operator_name, bool right_side
+    const std::string& left_side_identifier, ComparisonOperator comparison_operator, bool right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(right_side) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(right_side) {}
 
 LiteralCondition::LiteralCondition(
-    std::string_view left_side_identifier, std::string_view operator_name, bool right_side
+    std::string_view left_side_identifier, ComparisonOperator comparison_operator, bool right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(right_side) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(right_side) {}
 
 LiteralCondition::LiteralCondition(
-    const std::string& left_side_identifier, const std::string& operator_name, int right_side
+    const std::string& left_side_identifier, ComparisonOperator comparison_operator, int right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(right_side * 100) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(right_side * 100) {}
 
 LiteralCondition::LiteralCondition(
-    std::string_view left_side_identifier, std::string_view operator_name, int right_side
+    std::string_view left_side_identifier, ComparisonOperator comparison_operator, int right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(right_side * 100) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(right_side * 100) {}
 
 LiteralCondition::LiteralCondition(
-    const std::string& left_side_identifier, const std::string& operator_name, float right_side
+    const std::string& left_side_identifier, ComparisonOperator comparison_operator, float right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(static_cast<int>(right_side * 100)) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(static_cast<int>(right_side * 100)) {}
 
 LiteralCondition::LiteralCondition(
-    std::string_view left_side_identifier, std::string_view operator_name, float right_side
+    std::string_view left_side_identifier, ComparisonOperator comparison_operator, float right_side
 )
-    : Condition(left_side_identifier, operator_name), right_side(static_cast<int>(right_side * 100)) {}
+    : Condition(left_side_identifier, comparison_operator), right_side(static_cast<int>(right_side * 100)) {}
 
-bool LiteralCondition::evaluate(
-    const std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-) const {
-    if (comparison_operator == nullptr) {
-        return false;
-    } else if (attributes.contains(left_side_identifier)) {
-        return comparison_operator(attributes.at(left_side_identifier), right_side);
-    } else if (constants.contains(left_side_identifier)) {
-        return comparison_operator(constants.at(left_side_identifier), right_side);
-    }
-    throw std::out_of_range("Identifier \"" + left_side_identifier + "\" not found.");
+tl::expected<bool, RuntimeError> LiteralCondition::evaluate(const Stats& stats) const {
+    return evaluate_with_right_side(stats, right_side);
 }
 
 } // namespace dnd

--- a/src/core/models/effects/condition/literal_condition.hpp
+++ b/src/core/models/effects/condition/literal_condition.hpp
@@ -5,8 +5,11 @@
 
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <tl/expected.hpp>
+
+#include <core/errors/runtime_error.hpp>
+#include <core/models/character/stats.hpp>
 #include <core/models/effects/condition/condition.hpp>
 
 namespace dnd {
@@ -16,71 +19,14 @@ namespace dnd {
  */
 class LiteralCondition : public Condition {
 public:
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side boolean
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, bool right_side);
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side boolean
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, bool right_side);
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side integer
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, int right_side);
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side integer
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, int right_side);
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side float
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(const std::string& left_side_identifier, const std::string& operator_name, float right_side);
-    /**
-     * @brief Constructs a condition with the given left side identifier, operator, and right side float
-     * CAREFUL: if the operator is not found, the construction doesn't fail, but the condition will always evaluate to
-     * false
-     * @param left_side_identifier the identifier on the left side of the condition
-     * @param operator_name the name of the operator
-     * @param right_side the right side of the condition
-     */
-    LiteralCondition(std::string_view left_side_identifier, std::string_view operator_name, float right_side);
-    /**
-     * @brief Evaluates the condition for given attributes and constants
-     * @param attributes a map of attributes
-     * @param constants a map of constants
-     * @return "true" if the condition is fulfilled, "false" otherwise (or if the operator does not exist)
-     * @throws std::out_of_range if the identifier used in the condition doesn't exist among the given attributes and
-     * constants
-     */
-    virtual bool evaluate(
-        const std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const override final;
+    LiteralCondition(const std::string& left_side_identifier, ComparisonOperator comparison_operator, bool right_side);
+    LiteralCondition(std::string_view left_side_identifier, ComparisonOperator comparison_operator, bool right_side);
+    LiteralCondition(const std::string& left_side_identifier, ComparisonOperator comparison_operator, int right_side);
+    LiteralCondition(std::string_view left_side_identifier, ComparisonOperator comparison_operator, int right_side);
+    LiteralCondition(const std::string& left_side_identifier, ComparisonOperator comparison_operator, float right_side);
+    LiteralCondition(std::string_view left_side_identifier, ComparisonOperator comparison_operator, float right_side);
+
+    tl::expected<bool, RuntimeError> evaluate(const Stats& stats) const override final;
 private:
     int right_side;
 };

--- a/src/core/models/effects/effects.hpp
+++ b/src/core/models/effects/effects.hpp
@@ -5,10 +5,11 @@
 
 #include <compare>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <vector>
 
+#include <tl/expected.hpp>
+
+#include <core/models/character/stats.hpp>
 #include <core/models/effects/choice/choice.hpp>
 #include <core/models/effects/condition/condition.hpp>
 #include <core/models/effects/stat_change/stat_change.hpp>
@@ -40,6 +41,7 @@ public:
     Effects(Effects&&) noexcept = default;
     Effects& operator=(Effects&&) noexcept = default;
 
+    bool empty() const;
     const std::vector<std::unique_ptr<Condition>>& get_activation_conditions() const;
     const std::vector<Choice>& get_choices() const;
     const std::vector<std::unique_ptr<StatChange>>& get_stat_changes() const;
@@ -48,18 +50,7 @@ public:
     const ProficiencyHolder& get_proficiencies() const;
     const RIVHolder& get_rivs() const;
 
-    bool empty() const;
-
-    /**
-     * @brief Checks whether the activation conditions are met for given attributes and constants
-     * @param attributes the character attributes
-     * @param constants the character constants
-     * @return "true" if the activation conditions are met for a character with these attributes and constants,
-     * "false" otherwise
-     */
-    bool is_active(
-        const std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const;
+    tl::expected<bool, Errors> is_active(const Stats& stats) const;
 
     void merge(Effects&& other);
 private:

--- a/src/core/models/effects/stat_change/identifier_stat_change.hpp
+++ b/src/core/models/effects/stat_change/identifier_stat_change.hpp
@@ -5,8 +5,8 @@
 
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <core/errors/errors.hpp>
 #include <core/models/effects/stat_change/stat_change.hpp>
 
 namespace dnd {
@@ -16,41 +16,15 @@ namespace dnd {
  */
 class IdentifierStatChange : public StatChange {
 public:
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and value
-     * identifier for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value_identifier the identifier for the value that is used in the operation
-     */
     IdentifierStatChange(
-        const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name,
+        const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation,
         const std::string& value_identifier
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and value
-     * identifier for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value_identifier the identifier for the value that is used in the operation
-     */
     IdentifierStatChange(
-        std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name,
+        std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation,
         std::string_view value_identifier
     );
-    /**
-     * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
-     * @param attributes character attributes may be used for calculation and one of them will be changed
-     * @param constants character constants may be used for calculation
-     * @throws std::out_of_range if no value is found for the value identifier
-     */
-    virtual void apply_to(
-        std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const override final;
+    Errors apply(Stats& stats) const override final;
 private:
     std::string value_identifier;
 };

--- a/src/core/models/effects/stat_change/literal_stat_change.cpp
+++ b/src/core/models/effects/stat_change/literal_stat_change.cpp
@@ -2,54 +2,44 @@
 
 #include "literal_stat_change.hpp"
 
-#include <functional>
-#include <stdexcept>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <core/errors/errors.hpp>
 #include <core/models/effects/stat_change/stat_change.hpp>
 
 namespace dnd {
 
 LiteralStatChange::LiteralStatChange(
-    const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, bool value
+    const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, bool value
 )
-    : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value)) {}
+    : StatChange(affected_attribute, time, operation), value(static_cast<int>(value)) {}
 
 LiteralStatChange::LiteralStatChange(
-    std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, bool value
+    std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, bool value
 )
-    : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value)) {}
+    : StatChange(affected_attribute, time, operation), value(static_cast<int>(value)) {}
 
 LiteralStatChange::LiteralStatChange(
-    const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, int value
+    const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, int value
 )
-    : StatChange(affected_attribute, time, operation_name), value(value * 100) {}
+    : StatChange(affected_attribute, time, operation), value(value * 100) {}
 
 LiteralStatChange::LiteralStatChange(
-    std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, int value
+    std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, int value
 )
-    : StatChange(affected_attribute, time, operation_name), value(value * 100) {}
+    : StatChange(affected_attribute, time, operation), value(value * 100) {}
 
 LiteralStatChange::LiteralStatChange(
-    const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, float value
+    const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, float value
 )
-    : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value * 100)) {}
+    : StatChange(affected_attribute, time, operation), value(static_cast<int>(value * 100)) {}
 
 LiteralStatChange::LiteralStatChange(
-    std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, float value
+    std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, float value
 )
-    : StatChange(affected_attribute, time, operation_name), value(static_cast<int>(value * 100)) {}
+    : StatChange(affected_attribute, time, operation), value(static_cast<int>(value * 100)) {}
 
-void LiteralStatChange::apply_to(
-    std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-) const {
-    DND_UNUSED(constants);
-    if (mathematical_operation == nullptr) {
-        return;
-    }
-    attributes[affected_attribute] = mathematical_operation(attributes[affected_attribute], value);
-}
+Errors LiteralStatChange::apply(Stats& stats) const { return apply_with_value(stats, value); }
 
 } // namespace dnd

--- a/src/core/models/effects/stat_change/literal_stat_change.hpp
+++ b/src/core/models/effects/stat_change/literal_stat_change.hpp
@@ -5,8 +5,8 @@
 
 #include <string>
 #include <string_view>
-#include <unordered_map>
 
+#include <core/errors/errors.hpp>
 #include <core/models/effects/stat_change/stat_change.hpp>
 
 namespace dnd {
@@ -16,86 +16,26 @@ namespace dnd {
  */
 class LiteralStatChange : public StatChange {
 public:
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and boolean value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the boolean value that is used in the operation
-     */
     LiteralStatChange(
-        const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, bool value
+        const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, bool value
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and boolean value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the boolean value that is used in the operation
-     */
     LiteralStatChange(
-        std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, bool value
+        std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, bool value
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and integer value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the integer value that is used in the operation
-     */
     LiteralStatChange(
-        const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, int value
+        const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, int value
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and integer value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the integer value that is used in the operation
-     */
     LiteralStatChange(
-        std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, int value
+        std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, int value
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and float value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the float value that is used in the operation
-     */
     LiteralStatChange(
-        const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name, float value
+        const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation, float value
     );
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name and float value
-     * for the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail, but this stat change will do nothing.
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     * @param value the float value that is used in the operation
-     */
     LiteralStatChange(
-        std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name, float value
+        std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation, float value
     );
-    /**
-     * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
-     * @param attributes character attributes may be used for calculation and one of them will be changed
-     * @param constants character constants may be used for calculation
-     */
-    virtual void apply_to(
-        std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const override final;
+
+    Errors apply(Stats& stats) const override final;
 private:
     int value;
 };

--- a/src/core/models/effects/stat_change/stat_change.cpp
+++ b/src/core/models/effects/stat_change/stat_change.cpp
@@ -2,6 +2,7 @@
 
 #include "stat_change.hpp"
 
+#include <cassert>
 #include <string>
 #include <string_view>
 

--- a/src/core/models/effects/stat_change/stat_change.hpp
+++ b/src/core/models/effects/stat_change/stat_change.hpp
@@ -3,10 +3,10 @@
 
 #include <dnd_config.hpp>
 
-#include <functional>
 #include <string>
 #include <string_view>
-#include <unordered_map>
+
+#include <core/errors/errors.hpp>
 
 namespace dnd {
 
@@ -23,6 +23,18 @@ enum class StatChangeTime {
     LATEST = 4
 };
 
+enum class StatChangeOperation {
+    ADD,
+    SUB,
+    MULT,
+    DIV,
+    SET,
+    MAX,
+    MIN,
+};
+
+class Stats;
+
 class StatChange {
 public:
     struct Data;
@@ -31,35 +43,15 @@ public:
 
     StatChangeTime get_time() const;
 
-    /**
-     * @brief Applies the stat change to a character's attributes given the attributes and constants of the character
-     * @param attributes character attributes may be used for calculation and one of them will be changed
-     * @param constants character constants may be used for calculation
-     */
-    virtual void apply_to(
-        std::unordered_map<std::string, int>& attributes, const std::unordered_map<std::string, int>& constants
-    ) const = 0;
+    virtual Errors apply(Stats& stats) const = 0;
 protected:
-    /**
-     * @brief Constructs a stat change with the attribute it affects, its execution time, and the name of the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     */
-    StatChange(const std::string& affected_attribute, StatChangeTime time, const std::string& operation_name);
-    /**
-     * @brief Constructs an Effect with the attribute it affects, its execution time, and the name of the operation.
-     * CAREFUL: if the operation is not found, the construction doesn't fail
-     * @param affected_attribute the name of the attribute whose calculation is affected by this stat change
-     * @param time the time at which this stat change should be applied in the order of execution
-     * @param operation_name the name of the mathematical operation that is performed when applying this stat change
-     */
-    StatChange(std::string_view affected_attribute, StatChangeTime time, std::string_view operation_name);
+    StatChange(const std::string& affected_attribute, StatChangeTime time, StatChangeOperation operation);
+    StatChange(std::string_view affected_attribute, StatChangeTime time, StatChangeOperation operation);
 
-    std::string affected_attribute;
-    std::function<int(int, int)> mathematical_operation;
+    Errors apply_with_value(Stats& stats, int value) const;
 private:
+    std::string affected_attribute;
+    StatChangeOperation operation;
     StatChangeTime time;
 };
 

--- a/src/core/models/effects/stat_change/stat_change_factory.cpp
+++ b/src/core/models/effects/stat_change/stat_change_factory.cpp
@@ -5,19 +5,57 @@
 #include <algorithm>
 #include <cassert>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
 
-#include <core/errors/errors.hpp>
-#include <core/exceptions/validation_exceptions.hpp>
+#include <fmt/format.h>
 
+#include <core/errors/errors.hpp>
+#include <core/errors/validation_error.hpp>
 #include <core/models/effects/stat_change/identifier_stat_change.hpp>
 #include <core/models/effects/stat_change/literal_stat_change.hpp>
 #include <core/utils/string_manipulation.hpp>
 #include <core/validation/effects/stat_change/stat_change_validation.hpp>
 
 namespace dnd {
+
+static std::optional<StatChangeTime> stat_change_time_from_str(std::string_view stat_change_time_str) {
+    if (stat_change_time_str == "earliest") {
+        return StatChangeTime::EARLIEST;
+    } else if (stat_change_time_str == "early") {
+        return StatChangeTime::EARLY;
+    } else if (stat_change_time_str == "normal") {
+        return StatChangeTime::NORMAL;
+    } else if (stat_change_time_str == "late") {
+        return StatChangeTime::LATE;
+    } else if (stat_change_time_str == "latest") {
+        return StatChangeTime::LATEST;
+    }
+    assert(false);
+    return std::nullopt;
+}
+
+static std::optional<StatChangeOperation> stat_change_operation_from_str(std::string_view stat_change_operation_str) {
+    if (stat_change_operation_str == "add") {
+        return StatChangeOperation::ADD;
+    } else if (stat_change_operation_str == "sub") {
+        return StatChangeOperation::SUB;
+    } else if (stat_change_operation_str == "mult") {
+        return StatChangeOperation::MULT;
+    } else if (stat_change_operation_str == "div") {
+        return StatChangeOperation::DIV;
+    } else if (stat_change_operation_str == "set") {
+        return StatChangeOperation::SET;
+    } else if (stat_change_operation_str == "max") {
+        return StatChangeOperation::MAX;
+    } else if (stat_change_operation_str == "min") {
+        return StatChangeOperation::MIN;
+    }
+    assert(false);
+    return std::nullopt;
+}
 
 FactoryResult<StatChange> create_stat_change(StatChange::Data&& data) {
     Errors errors = validate_stat_change(data);
@@ -30,41 +68,53 @@ FactoryResult<StatChange> create_stat_change(StatChange::Data&& data) {
     it = std::find(it, data.stat_change_str.cend(), ' ');
 
     const std::string_view stat_change_time_str = str_view(last_it, it);
-    StatChangeTime stat_change_time = static_cast<StatChangeTime>(-1);
-    if (stat_change_time_str == "earliest") {
-        stat_change_time = StatChangeTime::EARLIEST;
-    } else if (stat_change_time_str == "early") {
-        stat_change_time = StatChangeTime::EARLY;
-    } else if (stat_change_time_str == "normal") {
-        stat_change_time = StatChangeTime::NORMAL;
-    } else if (stat_change_time_str == "late") {
-        stat_change_time = StatChangeTime::LATE;
-    } else if (stat_change_time_str == "latest") {
-        stat_change_time = StatChangeTime::LATEST;
+    std::optional<StatChangeTime> stat_change_time_optional = stat_change_time_from_str(stat_change_time_str);
+    if (!stat_change_time_optional.has_value()) {
+        Errors sub_errors = Errors(ValidationError(
+            ValidationError::Code::INVALID_ATTRIBUTE_VALUE,
+            fmt::format("Invalid stat change time '{}'", stat_change_time_str)
+        ));
+        return InvalidFactory<StatChange>(std::move(data), std::move(sub_errors));
     }
-    assert(stat_change_time != static_cast<StatChangeTime>(-1));
+    StatChangeTime stat_change_time = stat_change_time_optional.value();
 
     last_it = ++it;
     it = std::find(it, data.stat_change_str.cend(), ' ');
     const std::string_view operator_name = str_view(last_it, it);
+
+    std::optional<StatChangeOperation> operation_optional = stat_change_operation_from_str(operator_name);
+    if (!operation_optional.has_value()) {
+        Errors sub_errors = Errors(ValidationError(
+            ValidationError::Code::INVALID_ATTRIBUTE_VALUE,
+            fmt::format("Invalid stat change operation '{}'", operator_name)
+        ));
+        return InvalidFactory<StatChange>(std::move(data), std::move(sub_errors));
+    }
+    StatChangeOperation operation = operation_optional.value();
+
     const std::string_view value = str_view(++it, data.stat_change_str.cend());
 
     std::unique_ptr<StatChange> stat_change;
     if (value[0] >= 'A' && value[0] <= 'Z') {
-        stat_change = std::make_unique<IdentifierStatChange>(
-            affected_attribute, stat_change_time, operator_name, value
-        );
+        stat_change = std::make_unique<IdentifierStatChange>(affected_attribute, stat_change_time, operation, value);
     } else if (value == "true" || value == "false") {
+        if (operation != StatChangeOperation::SET) {
+            Errors sub_errors = Errors(ValidationError(
+                ValidationError::Code::INVALID_ATTRIBUTE_VALUE,
+                fmt::format("Boolean values only support the 'set' operation, '{}' is invalid.", operator_name)
+            ));
+            return InvalidFactory<StatChange>(std::move(data), std::move(sub_errors));
+        }
         stat_change = std::make_unique<LiteralStatChange>(
-            affected_attribute, stat_change_time, operator_name, value == "true"
+            affected_attribute, stat_change_time, operation, value == "true"
         );
     } else if (value.find('.') != std::string::npos) {
         stat_change = std::make_unique<LiteralStatChange>(
-            affected_attribute, stat_change_time, operator_name, std::stof(value.data())
+            affected_attribute, stat_change_time, operation, std::stof(std::string(value))
         );
     } else {
         stat_change = std::make_unique<LiteralStatChange>(
-            affected_attribute, stat_change_time, operator_name, std::stoi(value.data())
+            affected_attribute, stat_change_time, operation, std::stoi(std::string(value))
         );
     }
     return ValidFactory(std::move(stat_change));

--- a/src/core/models/spell/spell_type.cpp
+++ b/src/core/models/spell/spell_type.cpp
@@ -84,9 +84,16 @@ std::string SpellType::str() const {
             return fmt::format("2nd-level spell - School of {}", capitalized_school_name);
         case SpellLevel::LEVEL3:
             return fmt::format("3rd-level spell - School of {}", capitalized_school_name);
-        default:
+        case SpellLevel::LEVEL4:
+        case SpellLevel::LEVEL5:
+        case SpellLevel::LEVEL6:
+        case SpellLevel::LEVEL7:
+        case SpellLevel::LEVEL8:
+        case SpellLevel::LEVEL9:
             return fmt::format("{}th-level spell - School of {}", get_spell_level_as_int(), capitalized_school_name);
     }
+    assert(false);
+    return "";
 }
 
 std::string SpellType::short_str() const {
@@ -99,9 +106,16 @@ std::string SpellType::short_str() const {
             return fmt::format("2nd-level {}", get_magic_school_name());
         case SpellLevel::LEVEL3:
             return fmt::format("3rd-level {}", get_magic_school_name());
-        default:
+        case SpellLevel::LEVEL4:
+        case SpellLevel::LEVEL5:
+        case SpellLevel::LEVEL6:
+        case SpellLevel::LEVEL7:
+        case SpellLevel::LEVEL8:
+        case SpellLevel::LEVEL9:
             return fmt::format("{}th-level {}", get_spell_level_as_int(), get_magic_school_name());
     }
+    assert(false);
+    return "";
 }
 
 } // namespace dnd

--- a/src/core/models/spellcasting/preparation_spellcasting.cpp
+++ b/src/core/models/spellcasting/preparation_spellcasting.cpp
@@ -17,19 +17,17 @@ int PreparationSpellcasting::get_prepared_spells_amount(AbilityScores ability_sc
     if (level < 1 || level > 20) {
         return 0;
     }
-    int prepared_spells_amount = 0;
+    int prepared_spells_amount = ability_scores.get_modifier(get_ability());
     switch (type) {
         case PreparationSpellcastingType::HALF:
             prepared_spells_amount += level / 2;
-            break;
+            return prepared_spells_amount;
         case PreparationSpellcastingType::FULL:
             prepared_spells_amount += level;
-            break;
-        default:
-            return 0;
+            return prepared_spells_amount;
     }
-    prepared_spells_amount += ability_scores.get_modifier(get_ability());
-    return prepared_spells_amount;
+    assert(false);
+    return 0;
 }
 
 PreparationSpellcasting::PreparationSpellcasting(

--- a/src/core/models/spellcasting/preparation_spellcasting.cpp
+++ b/src/core/models/spellcasting/preparation_spellcasting.cpp
@@ -3,6 +3,7 @@
 #include "preparation_spellcasting.hpp"
 
 #include <array>
+#include <cassert>
 #include <utility>
 
 #include <core/basic_mechanics/abilities.hpp>

--- a/src/core/models/spellcasting/preparation_spellcasting.hpp
+++ b/src/core/models/spellcasting/preparation_spellcasting.hpp
@@ -9,9 +9,6 @@
 
 namespace dnd {
 
-/**
- * @brief An enum for the types of preparation spell casters
- */
 enum class PreparationSpellcastingType {
     HALF,
     FULL,

--- a/src/core/parsing/content_parsing.cpp
+++ b/src/core/parsing/content_parsing.cpp
@@ -184,10 +184,9 @@ static Errors parse_file_of_type(const std::filesystem::path& file, Content& con
             return parse_file(content, SpellParser(file));
         case ParsingType::CHOOSABLES:
             return parse_file(content, ChoosableGroupParser(file));
-        default:
-            assert(false);
-            return Errors();
     }
+    assert(false);
+    return Errors();
 }
 
 static const char* type_directory_name(ParsingType type) {
@@ -208,10 +207,9 @@ static const char* type_directory_name(ParsingType type) {
             return "spells";
         case ParsingType::CHOOSABLES:
             return "groups";
-        default:
-            assert(false);
-            return "";
     }
+    assert(false);
+    return "";
 }
 
 static Errors parse_all_of_type(

--- a/src/core/searching/content_filters/bool_filter.cpp
+++ b/src/core/searching/content_filters/bool_filter.cpp
@@ -2,6 +2,8 @@
 
 #include "bool_filter.hpp"
 
+#include <cassert>
+
 namespace dnd {
 
 BoolFilter::BoolFilter() : type(BoolFilterType::NONE) {}

--- a/src/core/searching/content_filters/bool_filter.cpp
+++ b/src/core/searching/content_filters/bool_filter.cpp
@@ -24,9 +24,9 @@ bool BoolFilter::matches(bool boolean) const {
             return !boolean;
         case BoolFilterType::NONE:
             return true;
-        default:
-            return false;
     }
+    assert(false);
+    return false;
 }
 
 } // namespace dnd

--- a/src/core/searching/content_filters/number_filter.hpp
+++ b/src/core/searching/content_filters/number_filter.hpp
@@ -3,6 +3,7 @@
 
 #include <dnd_config.hpp>
 
+#include <cassert>
 #include <type_traits>
 
 namespace dnd {

--- a/src/core/searching/content_filters/number_filter.hpp
+++ b/src/core/searching/content_filters/number_filter.hpp
@@ -104,9 +104,9 @@ bool NumberFilter<T>::matches(T number) const {
             return number >= value;
         case NumberFilterType::NONE:
             return true;
-        default:
-            return false;
     }
+    assert(false);
+    return false;
 }
 
 } // namespace dnd

--- a/src/core/searching/content_filters/selection_filter.hpp
+++ b/src/core/searching/content_filters/selection_filter.hpp
@@ -97,9 +97,9 @@ bool SelectionFilter<T>::matches(const T& selection) const {
             return std::find(values.begin(), values.end(), selection) == values.end();
         case SelectionFilterType::NONE:
             return true;
-        default:
-            return false;
     }
+    assert(false);
+    return false;
 }
 
 } // namespace dnd

--- a/src/core/searching/content_filters/selection_filter.hpp
+++ b/src/core/searching/content_filters/selection_filter.hpp
@@ -4,6 +4,7 @@
 #include <dnd_config.hpp>
 
 #include <algorithm>
+#include <cassert>
 #include <utility>
 #include <vector>
 

--- a/src/core/searching/content_filters/string_filter.cpp
+++ b/src/core/searching/content_filters/string_filter.cpp
@@ -2,6 +2,7 @@
 
 #include "string_filter.hpp"
 
+#include <cassert>
 #include <string>
 
 namespace dnd {
@@ -57,9 +58,9 @@ bool StringFilter::matches(const std::string& str) const {
             return str.rfind(value) != str.size() - value.size();
         case StringFilterType::NONE:
             return true;
-        default:
-            return false;
     }
+    assert(false);
+    return false;
 }
 
 } // namespace dnd

--- a/src/core/validation/effects/choice/choice_validation.cpp
+++ b/src/core/validation/effects/choice/choice_validation.cpp
@@ -139,16 +139,20 @@ Errors validate_choice_raw(const Choice::Data& data) {
     switch (type) {
         case ChoiceType::ABILITY:
             errors += validate_ability_choice(data);
-            break;
+            return errors;
         case ChoiceType::SKILL:
             errors += validate_skill_choice(data);
-            break;
+            return errors;
         case ChoiceType::STAT_CHANGE:
             errors += validate_stat_change_choice(data);
-            break;
-        default:
-            break;
+            return errors;
+        case ChoiceType::STRING:
+        case ChoiceType::ITEM:
+        case ChoiceType::SPELL:
+        case ChoiceType::CHOOSABLE:
+            return errors;
     }
+    assert(false);
     return errors;
 }
 
@@ -354,20 +358,22 @@ static Errors validate_choice_relations(const Choice::Data& data, const Content&
     switch (type) {
         case ChoiceType::STRING:
             errors += validate_relations_string_choice(data, content);
-            break;
+            return errors;
         case ChoiceType::ITEM:
             errors += validate_relations_item_choice(data, content);
-            break;
+            return errors;
         case ChoiceType::SPELL:
             errors += validate_relations_spell_choice(data, content);
-            break;
+            return errors;
         case ChoiceType::CHOOSABLE:
             errors += validate_relations_choosable_choice(data, content);
-            break;
-        default:
-            break;
+            return errors;
+        case ChoiceType::ABILITY:
+        case ChoiceType::SKILL:
+        case ChoiceType::STAT_CHANGE:
+            return errors;
     }
-
+    assert(false);
     return errors;
 }
 

--- a/src/gui/gui_app.cpp
+++ b/src/gui/gui_app.cpp
@@ -130,7 +130,8 @@ void GuiApp::render_overview_window() {
         case SessionStatus::READY:
             render_content_count_table(session.get_content());
             break;
-        default:
+        case SessionStatus::UNKNOWN_ERROR:
+            ImGui::Text("An unknown error occurred");
             break;
     }
     ImGui::End();

--- a/src/gui/visitors/filters/filter_setting_visitor.cpp
+++ b/src/gui/visitors/filters/filter_setting_visitor.cpp
@@ -239,8 +239,6 @@ static void visit_content_piece_filter(ContentPieceFilter& content_piece_filter)
         case 1:
             visit_selection_filter("Name", std::get<1>(name_filter));
             break;
-        default:
-            break;
     }
     visit_string_filter("Description", content_piece_filter.description_filter);
     visit_bool_filter("Is Sourcebook", content_piece_filter.is_sourcebook_filter);

--- a/src/gui/windows/advanced_search_window.cpp
+++ b/src/gui/windows/advanced_search_window.cpp
@@ -37,6 +37,33 @@ static constexpr std::array<const char*, 10> content_filter_names = {
     "Any", "Characters", "Classes", "Subclasses", "Species", "Subspecies", "Items", "Spells", "Features", "Choosables",
 };
 
+static ContentPieceFilter get_filter_from_filter_index(size_t idx) {
+    switch (idx) {
+        case 0:
+            return ContentPieceFilter();
+        case 1:
+            return CharacterFilter();
+        case 2:
+            return ClassFilter();
+        case 3:
+            return SubclassFilter();
+        case 4:
+            return SpeciesFilter();
+        case 5:
+            return SubspeciesFilter();
+        case 6:
+            return ItemFilter();
+        case 7:
+            return SpellFilter();
+        case 8:
+            return FeatureFilter();
+        case 9:
+            return ChoosableFilter();
+    }
+    assert(false);
+    return ContentPieceFilter();
+}
+
 AdvancedSearchWindow::AdvancedSearchWindow(Session& session) : session(session), result_list() {}
 
 void AdvancedSearchWindow::render() {
@@ -73,40 +100,7 @@ void AdvancedSearchWindow::render() {
         ImGui::EndCombo();
     }
     if (swap_to_idx != content_filter_names.size()) {
-        switch (swap_to_idx) {
-            case 0:
-                filter = ContentPieceFilter();
-                break;
-            case 1:
-                filter = CharacterFilter();
-                break;
-            case 2:
-                filter = ClassFilter();
-                break;
-            case 3:
-                filter = SubclassFilter();
-                break;
-            case 4:
-                filter = SpeciesFilter();
-                break;
-            case 5:
-                filter = SubspeciesFilter();
-                break;
-            case 6:
-                filter = ItemFilter();
-                break;
-            case 7:
-                filter = SpellFilter();
-                break;
-            case 8:
-                filter = FeatureFilter();
-                break;
-            case 9:
-                filter = ChoosableFilter();
-                break;
-            default:
-                assert(false);
-        }
+        filter = get_filter_from_filter_index(swap_to_idx);
     }
 
     std::visit(filter_setting_visitor, filter);

--- a/src/gui/windows/content_configuration_window.cpp
+++ b/src/gui/windows/content_configuration_window.cpp
@@ -25,13 +25,16 @@ void ContentConfigurationWindow::initialize() {
     switch (session.get_status()) {
         case SessionStatus::CONTENT_DIR_SELECTION:
             open_content_directory_selection();
-            break;
+            return;
         case SessionStatus::CAMPAIGN_SELECTION:
             is_selecting_campaign = true;
-            break;
-        default:
-            break;
+            return;
+        case SessionStatus::PARSING:
+        case SessionStatus::READY:
+        case SessionStatus::UNKNOWN_ERROR:
+            return;
     }
+    assert(false);
 }
 
 void ContentConfigurationWindow::open_content_directory_selection() {

--- a/tests/testcore/basic_mechanics/abilities_test.cpp
+++ b/tests/testcore/basic_mechanics/abilities_test.cpp
@@ -4,36 +4,34 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include <stdexcept>
-
 namespace dnd::test {
 
 static constexpr const char* tags = "[core][basic_mechanics]";
 
 TEST_CASE("string_to_ability", tags) {
     SECTION("Valid ability strings") {
-        REQUIRE(string_to_ability("STR") == Ability::STRENGTH);
-        REQUIRE(string_to_ability("DEX") == Ability::DEXTERITY);
-        REQUIRE(string_to_ability("CON") == Ability::CONSTITUTION);
-        REQUIRE(string_to_ability("INT") == Ability::INTELLIGENCE);
-        REQUIRE(string_to_ability("WIS") == Ability::WISDOM);
-        REQUIRE(string_to_ability("CHA") == Ability::CHARISMA);
+        REQUIRE(ability_from_string("STR").value() == Ability::STRENGTH);
+        REQUIRE(ability_from_string("DEX").value() == Ability::DEXTERITY);
+        REQUIRE(ability_from_string("CON").value() == Ability::CONSTITUTION);
+        REQUIRE(ability_from_string("INT").value() == Ability::INTELLIGENCE);
+        REQUIRE(ability_from_string("WIS").value() == Ability::WISDOM);
+        REQUIRE(ability_from_string("CHA").value() == Ability::CHARISMA);
     }
 
     SECTION("Invalid ability strings") {
-        REQUIRE_THROWS_AS(string_to_ability("XYZ"), std::invalid_argument);
-        REQUIRE_THROWS_AS(string_to_ability("ABCD"), std::invalid_argument);
-        REQUIRE_THROWS_AS(string_to_ability(""), std::invalid_argument);
+        REQUIRE_FALSE(ability_from_string("XYZ").has_value());
+        REQUIRE_FALSE(ability_from_string("ABCD").has_value());
+        REQUIRE_FALSE(ability_from_string("").has_value());
     }
 }
 
 TEST_CASE("ability_to_string", tags) {
-    REQUIRE(ability_to_string(Ability::STRENGTH) == "STR");
-    REQUIRE(ability_to_string(Ability::DEXTERITY) == "DEX");
-    REQUIRE(ability_to_string(Ability::CONSTITUTION) == "CON");
-    REQUIRE(ability_to_string(Ability::INTELLIGENCE) == "INT");
-    REQUIRE(ability_to_string(Ability::WISDOM) == "WIS");
-    REQUIRE(ability_to_string(Ability::CHARISMA) == "CHA");
+    REQUIRE(ability_name(Ability::STRENGTH) == "STR");
+    REQUIRE(ability_name(Ability::DEXTERITY) == "DEX");
+    REQUIRE(ability_name(Ability::CONSTITUTION) == "CON");
+    REQUIRE(ability_name(Ability::INTELLIGENCE) == "INT");
+    REQUIRE(ability_name(Ability::WISDOM) == "WIS");
+    REQUIRE(ability_name(Ability::CHARISMA) == "CHA");
 }
 
 TEST_CASE("is_ability // string_view implementation", tags) {


### PR DESCRIPTION
This PR introduces a new class that manages character `Stats`.
This allows a better abstraction than the prior solution with two maps which would be passed to conditions and stat changes.
Accordingly, I refactored the condition and stat change classes to use `Stats` instead.

Additionally, I adjusted some switch statements in a way that the compiler will throw errors when the enum is changed but the switch statements are not.
And I added assertions for the paths only taken by invalid enum values.